### PR TITLE
Ajustes no Docker e arquivos de ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-@"
 # Node.js
 node_modules/
 npm-debug.log*
@@ -20,4 +19,3 @@ Thumbs.db
 .env
 .env.local
 .env.*.local
-"@ > .gitignore

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mongo:
     image: mongo:4.4
@@ -29,6 +27,7 @@ services:
       - mongo
     volumes:
       - ./api:/app
+      - /app/node_modules
     restart: always
 
   web:
@@ -42,6 +41,7 @@ services:
       - api
     volumes:
       - ./web:/app
+      - /app/node_modules
     restart: always
 
 volumes:

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log*
+.next
+out


### PR DESCRIPTION
## Resumo
- Evita copiar `node_modules` para as imagens adicionando `.dockerignore` para API e Web
- Protege os `node_modules` dos containers com volumes separados no `docker-compose`
- Limpa e organiza `.gitignore`

