### PR TITLE
feat: add pastel palette and button styles

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3,10 +3,14 @@
 @tailwind utilities;
 
 :root {
-  --background: #FDFBF5;
-  --foreground: #41424C;
-  --accent: #A4B0BE;
-  --accent-secondary: #B49B85;
+  --background: #f5f5f0;
+  --foreground: #2e2e2e;
+  --highlight-blue: #a8d8ea;
+  --highlight-blue-hover: #92c5d6;
+  --highlight-aqua: #b8e6d5;
+  --highlight-aqua-hover: #a1d4c0;
+  --highlight-salmon: #ffb4a2;
+  --highlight-salmon-hover: #e89d8d;
 }
 
 body {
@@ -16,5 +20,33 @@ body {
 }
 
 a {
-  color: var(--accent);
+  color: var(--highlight-blue);
+}
+
+@layer components {
+  .btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    font-weight: 500;
+    color: var(--foreground);
+    transition: background-color 0.3s ease;
+  }
+  .btn-blue {
+    background-color: var(--highlight-blue);
+  }
+  .btn-blue:hover {
+    background-color: var(--highlight-blue-hover);
+  }
+  .btn-aqua {
+    background-color: var(--highlight-aqua);
+  }
+  .btn-aqua:hover {
+    background-color: var(--highlight-aqua-hover);
+  }
+  .btn-salmon {
+    background-color: var(--highlight-salmon);
+  }
+  .btn-salmon:hover {
+    background-color: var(--highlight-salmon-hover);
+  }
 }

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -10,8 +10,12 @@ module.exports = {
       colors: {
         background: 'var(--background)',
         foreground: 'var(--foreground)',
-        accent: 'var(--accent)',
-        'accent-secondary': 'var(--accent-secondary)',
+        'highlight-blue': 'var(--highlight-blue)',
+        'highlight-blue-hover': 'var(--highlight-blue-hover)',
+        'highlight-aqua': 'var(--highlight-aqua)',
+        'highlight-aqua-hover': 'var(--highlight-aqua-hover)',
+        'highlight-salmon': 'var(--highlight-salmon)',
+        'highlight-salmon-hover': 'var(--highlight-salmon-hover)',
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],


### PR DESCRIPTION
## Summary
- add off-white base and pastel highlight color variables
- create solid button utility classes with hover transitions
- expose new color variables through Tailwind config

## Testing
- `npm run lint` *(fails: prompts "How would you like to configure ESLint?")*

------
https://chatgpt.com/codex/tasks/task_b_68981edde0808322869a4cf977a3de59