### PR TITLE
feat: add artist profile page with follow and gallery

### DIFF
--- a/web/src/app/(public)/artists/[artistId]/page.tsx
+++ b/web/src/app/(public)/artists/[artistId]/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Image from "next/image";
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "next/navigation";
+import { api } from "@/lib/api";
+import { Artist, Image as ImageType } from "@/types";
+import GalleryGrid from "@/components/GalleryGrid";
+import FollowButton from "@/components/FollowButton";
+
+export default function ArtistPage() {
+  const params = useParams();
+  const artistId = params?.artistId as string;
+
+  const { data: artist, isLoading: artistLoading } = useQuery({
+    queryKey: ["artist", artistId],
+    queryFn: async () => {
+      const res = await api.get(`/artists/${artistId}`);
+      return res.data as Artist;
+    },
+    enabled: !!artistId,
+  });
+
+  const { data: images = [], isLoading: imagesLoading } = useQuery({
+    queryKey: ["artistImages", artistId],
+    queryFn: async () => {
+      const res = await api.get(`/artists/${artistId}/images`);
+      return res.data.images as ImageType[];
+    },
+    enabled: !!artistId,
+  });
+
+  const { data: followData } = useQuery({
+    queryKey: ["followStatus", artistId],
+    queryFn: async () => {
+      const res = await api.get(`/artists/${artistId}/follow`);
+      return res.data as { isFollowing: boolean };
+    },
+    enabled: !!artistId,
+  });
+
+  if (artistLoading) {
+    return <div className="p-8">Carregando...</div>;
+  }
+
+  if (!artist) {
+    return <div className="p-8">Artista não encontrado.</div>;
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-8">
+      <div className="flex items-center gap-4">
+        <Image
+          src={artist.avatarUrl}
+          alt={artist.name}
+          width={96}
+          height={96}
+          className="rounded-full object-cover"
+        />
+        <div className="flex-1">
+          <h1 className="text-3xl font-bold">{artist.name}</h1>
+          <p className="text-muted-foreground">{artist.bio}</p>
+        </div>
+        {followData && (
+          <FollowButton artistId={artistId} isFollowing={followData.isFollowing} />
+        )}
+      </div>
+      {imagesLoading ? (
+        <div>Carregando galeria...</div>
+      ) : (
+        <GalleryGrid images={images} />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/FollowButton.tsx
+++ b/web/src/components/FollowButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useAuth } from "@/hooks/useAuth";
+import { Button } from "./ui/button";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useToast } from "./ui/use-toast";
+
+interface FollowButtonProps {
+  artistId: string;
+  isFollowing: boolean;
+}
+
+export default function FollowButton({ artistId, isFollowing }: FollowButtonProps) {
+  const { isAuthenticated } = useAuth();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const mutation = useMutation({
+    mutationFn: (currentlyFollowing: boolean) =>
+      currentlyFollowing
+        ? api.delete(`/artists/${artistId}/follow`)
+        : api.post(`/artists/${artistId}/follow`),
+    onSuccess: (_, currentlyFollowing) => {
+      queryClient.invalidateQueries({ queryKey: ["followStatus", artistId] });
+      toast({
+        title: "Sucesso!",
+        description: currentlyFollowing
+          ? "Você deixou de seguir o artista."
+          : "Agora você segue este artista.",
+        variant: "default",
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Erro",
+        description: "Não foi possível atualizar o status de seguidor.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  const handleToggle = () => {
+    mutation.mutate(isFollowing);
+  };
+
+  return (
+    <Button onClick={handleToggle} variant={isFollowing ? "secondary" : "default"}>
+      {isFollowing ? "Seguindo" : "Seguir"}
+    </Button>
+  );
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -30,3 +30,10 @@ export interface Image {
   tags?: string[];
   createdAt: string;
 }
+
+export interface Artist {
+  _id: string;
+  name: string;
+  bio: string;
+  avatarUrl: string;
+}


### PR DESCRIPTION
## Summary
- add Artist type
- add reusable FollowButton component
- create artist profile page with gallery and follow integration

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_68981eda6ed48322af8140715877145c