### PR TITLE
feat: add search, profiles and interactions

### DIFF
--- a/api/src/controllers/commentController.js
+++ b/api/src/controllers/commentController.js
@@ -1,0 +1,25 @@
+const commentService = require('../services/commentService');
+
+const addCommentController = async (req, res, next) => {
+    try {
+        const { imageId } = req.params;
+        const userId = req.user._id;
+        const { text } = req.body;
+        const comment = await commentService.addComment(userId, imageId, text);
+        res.status(201).json(comment);
+    } catch (err) {
+        next(err);
+    }
+};
+
+const getCommentsController = async (req, res, next) => {
+    try {
+        const { imageId } = req.params;
+        const comments = await commentService.getComments(imageId);
+        res.json(comments);
+    } catch (err) {
+        next(err);
+    }
+};
+
+module.exports = { addCommentController, getCommentsController };

--- a/api/src/controllers/galleryController.js
+++ b/api/src/controllers/galleryController.js
@@ -19,7 +19,9 @@ const getGalleryController = async (req, res, next) => {
 
 const createGalleryController = async (req, res, next) => {
     try {
-        const newImage = await galleryService.createGalleryImage(req.body);
+        const authorId = req.user._id;
+        const authorName = req.user.name || req.user.email;
+        const newImage = await galleryService.createGalleryImage({ ...req.body, authorId, authorName });
         res.status(201).json(newImage);
     } catch (err) {
         next(err);

--- a/api/src/controllers/userController.js
+++ b/api/src/controllers/userController.js
@@ -1,0 +1,18 @@
+const User = require('../models/User');
+
+const updateProfileController = async (req, res, next) => {
+    try {
+        const userId = req.user._id;
+        const { name, avatarUrl, bio, socialLinks } = req.body;
+        const updated = await User.findByIdAndUpdate(
+            userId,
+            { name, avatarUrl, bio, socialLinks },
+            { new: true }
+        );
+        res.json(updated);
+    } catch (err) {
+        next(err);
+    }
+};
+
+module.exports = { updateProfileController };

--- a/api/src/models/Comment.js
+++ b/api/src/models/Comment.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const commentSchema = new mongoose.Schema({
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    imageId: { type: mongoose.Schema.Types.ObjectId, ref: 'Image', required: true },
+    text: { type: String, required: true },
+    createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Comment', commentSchema);
+

--- a/api/src/models/Image.js
+++ b/api/src/models/Image.js
@@ -4,6 +4,8 @@ const imageSchema = new mongoose.Schema({
     title: { type: String, required: true },
     url: { type: String, required: true },
     tags: [{ type: String }],
+    authorId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    authorName: { type: String, required: true },
     createdAt: { type: Date, default: Date.now }
 });
 

--- a/api/src/models/User.js
+++ b/api/src/models/User.js
@@ -10,6 +10,14 @@ const userSchema = new mongoose.Schema({
     email: { type: String, required: true, unique: true },
     password: { type: String, required: true },
     licenseExpiresAt: { type: Date, required: true },
+    name: { type: String },
+    avatarUrl: { type: String },
+    bio: { type: String },
+    socialLinks: {
+        website: { type: String },
+        instagram: { type: String },
+        twitter: { type: String }
+    },
     refreshTokens: [refreshTokenSchema]
 }, { timestamps: true });
 

--- a/api/src/routes/galleryRoutes.js
+++ b/api/src/routes/galleryRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { body, param } = require('express-validator');
 const { getGalleryController, createGalleryController, addLikeController, removeLikeController } = require('../controllers/galleryController');
+const { addCommentController, getCommentsController } = require('../controllers/commentController');
 const { authMiddleware, checkLicenseMiddleware } = require('../middlewares/auth');
 const { validate } = require('../middlewares/validate');
 
@@ -18,5 +19,10 @@ router.get('/', getGalleryController);
 router.post('/', authMiddleware, checkLicenseMiddleware, createGalleryImageValidation, validate, createGalleryController);
 router.post('/:imageId/like', authMiddleware, checkLicenseMiddleware, [param('imageId').isMongoId().withMessage('ID de imagem inválido.')], validate, addLikeController);
 router.delete('/:imageId/like', authMiddleware, checkLicenseMiddleware, [param('imageId').isMongoId().withMessage('ID de imagem inválido.')], validate, removeLikeController);
+router.get('/:imageId/comments', [param('imageId').isMongoId().withMessage('ID de imagem inválido.')], validate, getCommentsController);
+router.post('/:imageId/comments', authMiddleware, checkLicenseMiddleware, [
+    param('imageId').isMongoId().withMessage('ID de imagem inválido.'),
+    body('text').isString().notEmpty().withMessage('Texto do comentário é obrigatório.')
+], validate, addCommentController);
 
 module.exports = router;

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -2,11 +2,13 @@ const express = require('express');
 const authRoutes = require('./authRoutes');
 const licenseRoutes = require('./licenseRoutes');
 const galleryRoutes = require('./galleryRoutes');
+const userRoutes = require('./userRoutes');
 
 const apiRouter = express.Router();
 
 apiRouter.use('/auth', authRoutes);
 apiRouter.use('/license', licenseRoutes);
 apiRouter.use('/gallery', galleryRoutes);
+apiRouter.use('/users', userRoutes);
 
 module.exports = apiRouter;

--- a/api/src/routes/userRoutes.js
+++ b/api/src/routes/userRoutes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const { body } = require('express-validator');
+const { updateProfileController } = require('../controllers/userController');
+const { authMiddleware } = require('../middlewares/auth');
+const { validate } = require('../middlewares/validate');
+
+const router = express.Router();
+
+const profileValidation = [
+    body('name').optional().isString(),
+    body('avatarUrl').optional().isURL().withMessage('URL inválida.'),
+    body('bio').optional().isString(),
+    body('socialLinks').optional().isObject(),
+];
+
+router.put('/profile', authMiddleware, profileValidation, validate, updateProfileController);
+
+module.exports = router;

--- a/api/src/services/authService.js
+++ b/api/src/services/authService.js
@@ -16,7 +16,11 @@ const login = async (email, password) => {
         refreshToken,
         user: {
             email: user.email,
-            licenseExpiresAt: user.licenseExpiresAt
+            licenseExpiresAt: user.licenseExpiresAt,
+            name: user.name,
+            avatarUrl: user.avatarUrl,
+            bio: user.bio,
+            socialLinks: user.socialLinks
         }
     };
 };

--- a/api/src/services/commentService.js
+++ b/api/src/services/commentService.js
@@ -1,0 +1,15 @@
+const Comment = require('../models/Comment');
+
+const addComment = async (userId, imageId, text) => {
+    const comment = new Comment({ userId, imageId, text });
+    await comment.save();
+    return comment;
+};
+
+const getComments = async (imageId) => {
+    return Comment.find({ imageId })
+        .sort({ createdAt: -1 })
+        .populate('userId', 'name email avatarUrl');
+};
+
+module.exports = { addComment, getComments };

--- a/web/src/app/(public)/page.tsx
+++ b/web/src/app/(public)/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import GalleryGrid from "@/components/GalleryGrid";
+import SearchBar from "@/components/SearchBar";
 import { api } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
 import { Image } from "@/types";
+import { useState } from "react";
 
 interface GalleryResponse {
   images: Image[];
@@ -13,9 +15,10 @@ interface GalleryResponse {
 }
 
 export default function Home() {
+  const [search, setSearch] = useState("");
   const { data, isLoading, isError } = useQuery<GalleryResponse>({
-    queryKey: ['gallery'],
-    queryFn: () => api.get('/gallery').then(res => res.data),
+    queryKey: ['gallery', search],
+    queryFn: () => api.get(`/gallery?search=${search}`).then(res => res.data),
   });
 
   if (isLoading) return <div>Carregando galeria...</div>;
@@ -24,6 +27,7 @@ export default function Home() {
   return (
     <div className="flex flex-col gap-8">
       <h1 className="text-3xl font-bold">Galeria de Imagens</h1>
+      <SearchBar onSearch={setSearch} />
       <GalleryGrid images={data?.images || []} />
     </div>
   );

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -11,6 +11,12 @@ const inter = Inter({ subsets: ["latin"] });
 export const metadata: Metadata = {
   title: "Galeria de Imagens",
   description: "Uma galeria de imagens com autenticação e licenças.",
+  keywords: ["galeria", "arte", "imagens", "artistas"],
+  openGraph: {
+    title: "Galeria de Imagens",
+    description: "Compartilhe e descubra obras de arte digitais.",
+    type: "website",
+  }
 };
 
 export default function RootLayout({

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useAuth } from "@/hooks/useAuth";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { useMutation } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+const profileSchema = z.object({
+  name: z.string().optional(),
+  avatarUrl: z.string().url().optional(),
+  bio: z.string().optional(),
+  website: z.string().url().optional(),
+  instagram: z.string().url().optional(),
+  twitter: z.string().url().optional(),
+});
+
+export default function ProfilePage() {
+  const { user } = useAuth();
+  const form = useForm<z.infer<typeof profileSchema>>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      name: user?.name || "",
+      avatarUrl: user?.avatarUrl || "",
+      bio: user?.bio || "",
+      website: user?.socialLinks?.website || "",
+      instagram: user?.socialLinks?.instagram || "",
+      twitter: user?.socialLinks?.twitter || "",
+    }
+  });
+
+  const mutation = useMutation({
+    mutationFn: (data: z.infer<typeof profileSchema>) => api.put('/users/profile', {
+      name: data.name,
+      avatarUrl: data.avatarUrl,
+      bio: data.bio,
+      socialLinks: {
+        website: data.website,
+        instagram: data.instagram,
+        twitter: data.twitter,
+      }
+    }),
+  });
+
+  const onSubmit = (values: z.infer<typeof profileSchema>) => {
+    mutation.mutate(values);
+  };
+
+  return (
+    <div className="max-w-xl mx-auto flex flex-col gap-4">
+      <h1 className="text-2xl font-bold">Seu Perfil</h1>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField control={form.control} name="name" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nome</FormLabel>
+              <FormControl><Input {...field} /></FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
+          <FormField control={form.control} name="avatarUrl" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Foto</FormLabel>
+              <FormControl><Input {...field} /></FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
+          <FormField control={form.control} name="bio" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Bio</FormLabel>
+              <FormControl><Input {...field} /></FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
+          <FormField control={form.control} name="website" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Website</FormLabel>
+              <FormControl><Input {...field} /></FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
+          <FormField control={form.control} name="instagram" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Instagram</FormLabel>
+              <FormControl><Input {...field} /></FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
+          <FormField control={form.control} name="twitter" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Twitter</FormLabel>
+              <FormControl><Input {...field} /></FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
+          <Button type="submit" disabled={mutation.isPending}>Salvar</Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/web/src/components/Comments.tsx
+++ b/web/src/components/Comments.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { useAuth } from "@/hooks/useAuth";
+import { Input } from "./ui/input";
+
+interface CommentsProps {
+  imageId: string;
+}
+
+export default function Comments({ imageId }: CommentsProps) {
+  const { isAuthenticated, isLicensed } = useAuth();
+  const queryClient = useQueryClient();
+  const [text, setText] = useState("");
+
+  const { data } = useQuery({
+    queryKey: ['comments', imageId],
+    queryFn: () => api.get(`/gallery/${imageId}/comments`).then(res => res.data),
+  });
+
+  const mutation = useMutation({
+    mutationFn: () => api.post(`/gallery/${imageId}/comments`, { text }),
+    onSuccess: () => {
+      setText("");
+      queryClient.invalidateQueries({ queryKey: ['comments', imageId] });
+    }
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text) return;
+    mutation.mutate();
+  };
+
+  return (
+    <div className="flex flex-col gap-2 mt-4">
+      <ul className="max-h-48 overflow-y-auto space-y-1">
+        {data?.map((c: any) => (
+          <li key={c._id} className="text-sm"><strong>{c.userId?.name || c.userId?.email}:</strong> {c.text}</li>
+        ))}
+      </ul>
+      {isAuthenticated && isLicensed && (
+        <form onSubmit={handleSubmit} className="flex gap-2">
+          <Input value={text} onChange={(e) => setText(e.target.value)} placeholder="Comente" />
+        </form>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ImageCard.tsx
+++ b/web/src/components/ImageCard.tsx
@@ -19,7 +19,7 @@ export default function ImageCard({ image }: ImageCardProps) {
 
   return (
     <>
-      <Card className="relative group overflow-hidden cursor-pointer" onClick={() => setIsModalOpen(true)}>
+      <Card className="relative group overflow-hidden cursor-pointer opacity-0 animate-fade-in transition-shadow hover:shadow-lg" onClick={() => setIsModalOpen(true)}>
         <NextImage
           src={imageUrl}
           alt={image.title}
@@ -32,8 +32,13 @@ export default function ImageCard({ image }: ImageCardProps) {
         <div className="absolute top-2 right-2">
           <LikeButton imageId={image._id} />
         </div>
-        <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent text-white">
+        <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent text-white text-sm">
           <h3 className="font-semibold text-lg">{image.title}</h3>
+          <p className="text-xs">{image.authorName}</p>
+          <div className="flex gap-2 text-xs">
+            <span>{image.likes} ❤</span>
+            <span>{image.comments} 💬</span>
+          </div>
         </div>
       </Card>
       <Lightbox isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} image={image} />

--- a/web/src/components/Lightbox.tsx
+++ b/web/src/components/Lightbox.tsx
@@ -3,6 +3,7 @@
 import { Dialog, DialogContent } from "./ui/dialog";
 import NextImage from "next/image";
 import { Image as ImageType } from "@/types";
+import Comments from "./Comments";
 
 interface LightboxProps {
   isOpen: boolean;
@@ -14,14 +15,15 @@ export default function Lightbox({ isOpen, onClose, image }: LightboxProps) {
   const imageUrl = image.url || `${process.env.NEXT_PUBLIC_DRIVE_EMBED_PREFIX}${image.fileId}`;
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="p-0 border-none bg-transparent">
+      <DialogContent className="p-4 border-none bg-background flex flex-col items-center">
         <NextImage
           src={imageUrl}
           alt={image.title}
           width={image.width || 1200}
           height={image.height || 800}
-          className="rounded-lg max-h-[80vh] w-auto h-auto object-contain"
+          className="rounded-lg max-h-[60vh] w-auto h-auto object-contain"
         />
+        <Comments imageId={image._id} />
       </DialogContent>
     </Dialog>
   );

--- a/web/src/components/LikeButton.tsx
+++ b/web/src/components/LikeButton.tsx
@@ -6,6 +6,7 @@ import { Heart } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useToast } from "./ui/use-toast";
+import { useState } from "react";
 
 interface LikeButtonProps {
   imageId: string;
@@ -15,23 +16,19 @@ export default function LikeButton({ imageId }: LikeButtonProps) {
   const { isLicensed, isAuthenticated } = useAuth();
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const [liked, setLiked] = useState(false);
 
-  // Implementação otimista de likes. Você precisaria de um endpoint para likes/unlikes.
-  // Aqui, apenas um mock para demonstrar a interação.
   const likeMutation = useMutation({
-    mutationFn: () => api.post(`/gallery/${imageId}/like`),
+    mutationFn: () =>
+      liked ? api.delete(`/gallery/${imageId}/like`) : api.post(`/gallery/${imageId}/like`),
     onSuccess: () => {
+      setLiked(!liked);
       queryClient.invalidateQueries({ queryKey: ['gallery'] });
-      toast({
-        title: "Sucesso!",
-        description: "Imagem curtida com sucesso.",
-        variant: "default",
-      });
     },
     onError: () => {
       toast({
-        title: "Erro ao curtir",
-        description: "Você não tem permissão para curtir ou a licença expirou.",
+        title: "Erro",
+        description: "Não foi possível atualizar o like.",
         variant: "destructive",
       });
     }
@@ -47,7 +44,7 @@ export default function LikeButton({ imageId }: LikeButtonProps) {
 
   return (
     <Button variant="ghost" size="icon" onClick={handleLike} className="bg-white/50 hover:bg-white">
-      <Heart className="h-6 w-6 text-red-500" />
+      <Heart className={`h-6 w-6 ${liked ? 'fill-red-500 text-red-500' : 'text-red-500'}`} />
     </Button>
   );
 }

--- a/web/src/components/NavBar.tsx
+++ b/web/src/components/NavBar.tsx
@@ -26,6 +26,11 @@ export default function NavBar() {
             <Button variant="ghost">Upload</Button>
           </Link>
         )}
+        {isAuthenticated && (
+          <Link href="/profile">
+            <Button variant="ghost">Perfil</Button>
+          </Link>
+        )}
         {isAuthenticated && user && (
           <Link href="/license">
             <Badge variant={isLicensed ? "default" : "destructive"}>

--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Input } from "./ui/input";
+import { Image } from "@/types";
+
+interface SearchBarProps {
+  onSearch: (value: string) => void;
+}
+
+export default function SearchBar({ onSearch }: SearchBarProps) {
+  const [query, setQuery] = useState("");
+  const { data } = useQuery<Image[]>({
+    queryKey: ['search', query],
+    queryFn: () => api.get(`/gallery?search=${query}`).then(res => res.data.images),
+    enabled: query.length > 2
+  });
+
+  const suggestions = Array.from(new Set([
+    ...(data?.map(img => img.title) || []),
+    ...(data?.map(img => img.authorName) || [])
+  ])).slice(0,5);
+
+  const handleSelect = (value: string) => {
+    setQuery(value);
+    onSearch(value);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSearch(query);
+  };
+
+  return (
+    <div className="w-full max-w-md relative">
+      <form onSubmit={handleSubmit}>
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Buscar por título ou autor"
+        />
+      </form>
+      {suggestions.length > 0 && (
+        <ul className="absolute z-10 bg-white border w-full mt-1 rounded shadow">
+          {suggestions.map((s) => (
+            <li key={s} className="p-2 hover:bg-accent-secondary cursor-pointer" onClick={() => handleSelect(s)}>
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -5,6 +5,14 @@ import { UseMutateAsyncFunction } from "@tanstack/react-query";
 export interface User {
   email: string;
   licenseExpiresAt: string;
+  name?: string;
+  avatarUrl?: string;
+  bio?: string;
+  socialLinks?: {
+    website?: string;
+    instagram?: string;
+    twitter?: string;
+  };
 }
 
 export type LoginData = z.infer<typeof loginSchema>;
@@ -29,4 +37,7 @@ export interface Image {
   height?: number;
   tags?: string[];
   createdAt: string;
+  authorName: string;
+  likes: number;
+  comments: number;
 }

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -16,6 +16,15 @@ module.exports = {
       fontFamily: {
         sans: ['Inter', 'sans-serif'],
       },
+      keyframes: {
+        'fade-in': {
+          from: { opacity: '0' },
+          to: { opacity: '1' },
+        },
+      },
+      animation: {
+        'fade-in': 'fade-in 0.5s ease-in-out forwards',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- enable image search with autocomplete by title or author
- support user profiles with bio, avatar and links
- add comments, like counts and subtle animations

## Testing
- `npm test` (api)
- `npm test` (web)
- `npm run lint` (web)


------
https://chatgpt.com/codex/tasks/task_b_68981edec48c83228040aac44ee278a7