### PR TITLE
feat: showcase artworks on landing page

### DIFF
--- a/api/src/models/Image.js
+++ b/api/src/models/Image.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 
 const imageSchema = new mongoose.Schema({
     title: { type: String, required: true },
+    artist: { type: String, required: true, default: 'Desconhecido' },
     url: { type: String, required: true },
     tags: [{ type: String }],
     createdAt: { type: Date, default: Date.now }

--- a/web/src/app/(public)/page.tsx
+++ b/web/src/app/(public)/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+import Image from "next/image";
+import Link from "next/link";
 import GalleryGrid from "@/components/GalleryGrid";
 import { api } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
-import { Image } from "@/types";
+import { Image as ImageType } from "@/types";
 
 interface GalleryResponse {
-  images: Image[];
+  images: ImageType[];
   totalCount: number;
   totalPages: number;
   currentPage: number;
@@ -14,17 +16,57 @@ interface GalleryResponse {
 
 export default function Home() {
   const { data, isLoading, isError } = useQuery<GalleryResponse>({
-    queryKey: ['gallery'],
-    queryFn: () => api.get('/gallery').then(res => res.data),
+    queryKey: ['gallery', 'recent'],
+    queryFn: () =>
+      api
+        .get('/gallery', { params: { limit: 6 } })
+        .then(res => res.data),
   });
 
-  if (isLoading) return <div>Carregando galeria...</div>;
-  if (isError) return <div>Erro ao carregar galeria.</div>;
-
   return (
-    <div className="flex flex-col gap-8">
-      <h1 className="text-3xl font-bold">Galeria de Imagens</h1>
-      <GalleryGrid images={data?.images || []} />
+    <div className="flex flex-col gap-16">
+      <section className="relative h-96 w-full">
+        <Image
+          src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
+          alt="Destaque da galeria"
+          fill
+          priority
+          className="object-cover"
+          unoptimized
+        />
+        <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 text-white gap-4">
+          <h1 className="text-4xl font-bold text-center">Explore a Criatividade</h1>
+          <Link
+            href="#galeria"
+            className="px-6 py-3 bg-accent rounded-md text-lg"
+          >
+            Ver Galeria
+          </Link>
+        </div>
+      </section>
+
+      <section id="galeria" className="flex flex-col gap-8">
+        <h2 className="text-3xl font-bold text-center">Obras Recentes</h2>
+        {isLoading && <div>Carregando galeria...</div>}
+        {isError && <div>Erro ao carregar galeria.</div>}
+        {data && <GalleryGrid images={data.images} />}
+      </section>
+
+      <section className="flex flex-col md:flex-row items-center gap-8">
+        <Image
+          src="https://images.unsplash.com/photo-1526318472351-bc3c9c0ed911?auto=format&fit=crop&w=400&q=80"
+          alt="Sobre a galeria"
+          width={400}
+          height={300}
+          className="rounded-lg object-cover"
+          unoptimized
+        />
+        <p className="text-lg max-w-xl text-center md:text-left">
+          A LunaWEb é uma galeria digital dedicada a celebrar obras recentes e
+          artistas independentes. Inspire-se com as criações e descubra novos
+          talentos.
+        </p>
+      </section>
     </div>
   );
 }

--- a/web/src/components/ImageCard.tsx
+++ b/web/src/components/ImageCard.tsx
@@ -34,6 +34,7 @@ export default function ImageCard({ image }: ImageCardProps) {
         </div>
         <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent text-white">
           <h3 className="font-semibold text-lg">{image.title}</h3>
+          <p className="text-sm">por {image.artist}</p>
         </div>
       </Card>
       <Lightbox isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} image={image} />

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -23,6 +23,7 @@ export interface AuthContextType {
 export interface Image {
   _id: string;
   title: string;
+  artist: string;
   url?: string;
   fileId?: string;
   width?: number;


### PR DESCRIPTION
## Summary
- add artist field to image model
- display recent artworks with hero CTA and about section
- show artist caption on image cards
- load hero and about images from remote sources to avoid committing binaries

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompted for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_b_68981ed7621083228625df9b9309cfd1