### PR TITLE
Add API health check and console status logger

### DIFF
--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -5,6 +5,11 @@ const galleryRoutes = require('./galleryRoutes');
 
 const apiRouter = express.Router();
 
+// Rota simples para verificar se a API está respondendo
+apiRouter.get('/health', (req, res) => {
+    res.json({ status: 'ok' });
+});
+
 apiRouter.use('/auth', authRoutes);
 apiRouter.use('/license', licenseRoutes);
 apiRouter.use('/gallery', galleryRoutes);

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Header from "@/components/Header";
 import { Toaster } from "@/components/ui/toaster";
 import Providers from "@/components/Providers";
 import Footer from "@/components/Footer";
+import ApiStatusLogger from "@/components/ApiStatusLogger";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -22,6 +23,7 @@ export default function RootLayout({
     <html lang="pt-br">
       <body className={inter.className}>
         <Providers>
+          <ApiStatusLogger />
           <Header />
           <main className="container mx-auto p-4 md:p-8">
             {children}

--- a/web/src/components/ApiStatusLogger.tsx
+++ b/web/src/components/ApiStatusLogger.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+import { api } from '@/lib/api';
+
+// Componente que verifica a comunicação com a API e registra o resultado no console
+export default function ApiStatusLogger() {
+  useEffect(() => {
+    api.get('/health')
+      .then(() => {
+        console.log('API funcionando');
+      })
+      .catch((err) => {
+        console.error('Erro ao comunicar com a API', err);
+      });
+  }, []);
+
+  return null;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2,7 +2,8 @@ import axios from "axios";
 import { getRefreshToken, setAccessToken, setRefreshToken } from "./auth";
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  // Usa uma URL padrão caso a variável de ambiente não esteja definida
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3333/api/v1",
   headers: {
     "Content-Type": "application/json",
   },


### PR DESCRIPTION
## Summary
- add `/health` endpoint to confirm API is responsive
- default API URL fallback in frontend axios client
- log API status in browser console on app load

