### PR TITLE
Remove Google and Facebook login

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,13 +8,11 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
-        "@greatsumini/react-facebook-login": "^3.4.0",
         "@hookform/resolvers": "^5.2.1",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.1.1",
-        "@react-oauth/google": "^0.12.2",
         "@tanstack/react-query": "^5.49.2",
         "axios": "^1.7.2",
         "class-variance-authority": "^0.7.0",
@@ -148,15 +146,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@greatsumini/react-facebook-login": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@greatsumini/react-facebook-login/-/react-facebook-login-3.4.0.tgz",
-      "integrity": "sha512-NJYqTOcDghZ6zLppC+LJVLep7Xi3gfx9ssQFRd7EhDTU07lC15SG/eZ3ZyvUPsuPBkbhVl6E/Py0w4M5m7Lh9Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -951,16 +940,6 @@
         "@types/react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@react-oauth/google": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
-      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rtsao/scc": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,13 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@greatsumini/react-facebook-login": "^3.4.0",
     "@hookform/resolvers": "^5.2.1",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.1.1",
-    "@react-oauth/google": "^0.12.2",
     "@tanstack/react-query": "^5.49.2",
     "axios": "^1.7.2",
     "class-variance-authority": "^0.7.0",

--- a/web/src/components/AuthForm.tsx
+++ b/web/src/components/AuthForm.tsx
@@ -20,9 +20,6 @@ import { loginSchema, registerSchema } from "@/lib/validators";
 import Link from "next/link";
 import { useMutation } from "@tanstack/react-query";
 import { useToast } from "./ui/use-toast";
-import { GoogleLogin } from "@react-oauth/google";
-import FacebookLogin from "@greatsumini/react-facebook-login";
-import { useAuth } from "@/hooks/useAuth";
 
 type AuthFormType = "login" | "register";
 
@@ -39,8 +36,6 @@ interface AuthFormProps {
 const AuthForm = ({ type, onSubmit }: AuthFormProps) => {
   const router = useRouter();
   const { toast } = useToast();
-  const { loginWithGoogle, loginWithFacebook } = useAuth();
-
   const formSchema = type === "login" ? loginSchema : registerSchema;
 
   const form = useForm<FormValues>({
@@ -80,28 +75,6 @@ const AuthForm = ({ type, onSubmit }: AuthFormProps) => {
 
   function handleSubmit(data: FormValues) {
     mutation.mutate(data);
-  }
-
-  async function handleGoogleSuccess(credentialResponse: any) {
-    if (!credentialResponse?.credential) return;
-    try {
-      await loginWithGoogle(credentialResponse.credential);
-      toast({ title: "Sucesso!", description: "Você foi autenticado com sucesso." });
-      router.push("/");
-    } catch {
-      /* erro tratado no contexto */
-    }
-  }
-
-  async function handleFacebookSuccess(response: any) {
-    if (!response?.accessToken) return;
-    try {
-      await loginWithFacebook(response.accessToken);
-      toast({ title: "Sucesso!", description: "Você foi autenticado com sucesso." });
-      router.push("/");
-    } catch {
-      /* erro tratado no contexto */
-    }
   }
 
   return (
@@ -148,32 +121,6 @@ const AuthForm = ({ type, onSubmit }: AuthFormProps) => {
             </Button>
           </form>
         </Form>
-
-        {type === "login" && (
-          <div className="mt-4 flex flex-col space-y-2">
-            <GoogleLogin
-              onSuccess={handleGoogleSuccess}
-              onError={() =>
-                toast({
-                  title: "Erro na autenticação",
-                  description: "Falha ao entrar com Google.",
-                  variant: "destructive",
-                })
-              }
-            />
-            <FacebookLogin
-              appId={process.env.NEXT_PUBLIC_FACEBOOK_APP_ID || ""}
-              onSuccess={handleFacebookSuccess}
-              onFail={() =>
-                toast({
-                  title: "Erro na autenticação",
-                  description: "Falha ao entrar com Facebook.",
-                  variant: "destructive",
-                })
-              }
-            />
-          </div>
-        )}
 
         {type === "login" ? (
           <p className="mt-4 text-center text-sm text-gray-500">

--- a/web/src/components/Providers.tsx
+++ b/web/src/components/Providers.tsx
@@ -2,7 +2,6 @@
 
 import { ReactNode, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { GoogleOAuthProvider } from '@react-oauth/google';
 import { AuthProvider } from '@/lib/auth';
 
 interface ProvidersProps {
@@ -12,15 +11,11 @@ interface ProvidersProps {
 export default function Providers({ children }: ProvidersProps) {
   const [queryClient] = useState(() => new QueryClient());
 
-  const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || '';
-
   return (
     <QueryClientProvider client={queryClient}>
-      <GoogleOAuthProvider clientId={googleClientId}>
-        <AuthProvider>
-          {children}
-        </AuthProvider>
-      </GoogleOAuthProvider>
+      <AuthProvider>
+        {children}
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -5,7 +5,6 @@ import { api } from './api';
 import { User, AuthContextType, LoginData, RegisterData } from '@/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/components/ui/use-toast';
-import { useRouter } from 'next/navigation';
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -27,7 +26,6 @@ export const getRefreshToken = () => {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
-  const router = useRouter();
   const { toast } = useToast();
 
   const [accessToken, setLocalAccessToken] = useState<string | null>(null);
@@ -51,41 +49,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     },
   });
 
-  const loginGoogleMutation = useMutation({
-    mutationFn: (token: string) => api.post('/auth/google', { token }),
-    onSuccess: (res) => {
-      setAccessToken(res.data.accessToken);
-      setRefreshToken(res.data.refreshToken);
-      setLocalAccessToken(res.data.accessToken);
-      setLocalRefreshToken(res.data.refreshToken);
-      queryClient.setQueryData(['auth'], { user: res.data.user });
-    },
-    onError: (error: any) => {
-      toast({
-        title: "Erro de Login",
-        description: error.response?.data?.message || "Falha ao entrar com Google.",
-        variant: "destructive",
-      });
-    },
-  });
-
-  const loginFacebookMutation = useMutation({
-    mutationFn: (token: string) => api.post('/auth/facebook', { token }),
-    onSuccess: (res) => {
-      setAccessToken(res.data.accessToken);
-      setRefreshToken(res.data.refreshToken);
-      setLocalAccessToken(res.data.accessToken);
-      setLocalRefreshToken(res.data.refreshToken);
-      queryClient.setQueryData(['auth'], { user: res.data.user });
-    },
-    onError: (error: any) => {
-      toast({
-        title: "Erro de Login",
-        description: error.response?.data?.message || "Falha ao entrar com Facebook.",
-        variant: "destructive",
-      });
-    },
-  });
 
   const registerMutation = useMutation({
     mutationFn: (data: RegisterData) => api.post('/auth/create-user', data),
@@ -133,13 +96,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isLoading:
       loginMutation.isPending ||
       registerMutation.isPending ||
-      loginGoogleMutation.isPending ||
-      loginFacebookMutation.isPending ||
       isLicenseLoading,
     login: loginMutation.mutateAsync,
     register: registerMutation.mutateAsync,
-    loginWithGoogle: loginGoogleMutation.mutateAsync,
-    loginWithFacebook: loginFacebookMutation.mutateAsync,
     logout: logoutMutation.mutateAsync,
   };
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -18,8 +18,6 @@ export interface AuthContextType {
   isLoading: boolean;
   login: UseMutateAsyncFunction<any, Error, LoginData, unknown>;
   register: UseMutateAsyncFunction<any, Error, RegisterData, unknown>;
-  loginWithGoogle: UseMutateAsyncFunction<any, Error, string, unknown>;
-  loginWithFacebook: UseMutateAsyncFunction<any, Error, string, unknown>;
   logout: UseMutateAsyncFunction<void, Error, void, unknown>;
 }
 


### PR DESCRIPTION
## Summary
- remove Google/Facebook auth options and related context logic
- drop third-party login components and providers
- clean up auth context types and dependencies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_6898c93db4b08322be6d117416c3fdb0