### PR TITLE
fix: ensure gallery pagination params are valid

### DIFF
--- a/api/src/services/galleryService.js
+++ b/api/src/services/galleryService.js
@@ -8,7 +8,14 @@ const createGalleryImage = async (imageData) => {
 };
 
 const getGalleryImages = async (filters) => {
-    const { tags, search, technique, artist, date, page = 1, limit = 10 } = filters;
+    let { tags, search, technique, artist, date, page = 1, limit = 10 } = filters;
+
+    // Ensure page and limit are valid positive integers
+    page = parseInt(page, 10);
+    limit = parseInt(limit, 10);
+    if (isNaN(page) || page < 1) page = 1;
+    if (isNaN(limit) || limit < 1) limit = 10;
+
     const query = {};
 
     if (tags && tags.length > 0) {


### PR DESCRIPTION
## Summary
- validate page and limit query parameters when listing gallery images to prevent negative skip values

## Testing
- `node node_modules/jest/bin/jest.js --detectOpenHandles --forceExit` *(fails: invalid ELF header in bcrypt)*

------
https://chatgpt.com/codex/tasks/task_b_6898ccb7def08322ababb8c10280d3e2