### PR TITLE
Add profile page with password reset and logout

### DIFF
--- a/api/src/controllers/userController.js
+++ b/api/src/controllers/userController.js
@@ -1,0 +1,49 @@
+const userService = require('../services/userService');
+
+const getProfileController = (req, res) => {
+  const { _id, email, name, bio, licenseExpiresAt, role } = req.user;
+  res.json({
+    id: _id,
+    email,
+    name,
+    bio,
+    licenseExpiresAt,
+    role,
+  });
+};
+
+const updateProfileController = async (req, res, next) => {
+  try {
+    const { name, bio } = req.body;
+    const user = await userService.updateUserProfile(req.user._id, { name, bio });
+    res.json({
+      message: 'Perfil atualizado com sucesso.',
+      user: {
+        id: user._id,
+        email: user.email,
+        name: user.name,
+        bio: user.bio,
+        licenseExpiresAt: user.licenseExpiresAt,
+        role: user.role,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const changePasswordController = async (req, res, next) => {
+  try {
+    const { currentPassword, newPassword } = req.body;
+    await userService.changePassword(req.user._id, currentPassword, newPassword);
+    res.json({ message: 'Senha atualizada com sucesso.' });
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+module.exports = {
+  getProfileController,
+  updateProfileController,
+  changePasswordController,
+};

--- a/api/src/models/User.js
+++ b/api/src/models/User.js
@@ -9,6 +9,8 @@ const refreshTokenSchema = new mongoose.Schema({
 const userSchema = new mongoose.Schema({
     email: { type: String, required: true, unique: true },
     password: { type: String, required: true },
+    name: { type: String },
+    bio: { type: String },
     licenseExpiresAt: { type: Date, required: true },
     role: { type: String, enum: ['user', 'admin'], default: 'user' },
     refreshTokens: [refreshTokenSchema]

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const authRoutes = require('./authRoutes');
 const licenseRoutes = require('./licenseRoutes');
 const galleryRoutes = require('./galleryRoutes');
+const userRoutes = require('./userRoutes');
 
 const apiRouter = express.Router();
 
@@ -13,5 +14,6 @@ apiRouter.get('/health', (req, res) => {
 apiRouter.use('/auth', authRoutes);
 apiRouter.use('/license', licenseRoutes);
 apiRouter.use('/gallery', galleryRoutes);
+apiRouter.use('/users', userRoutes);
 
 module.exports = apiRouter;

--- a/api/src/routes/userRoutes.js
+++ b/api/src/routes/userRoutes.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const { body } = require('express-validator');
+const { getProfileController, updateProfileController, changePasswordController } = require('../controllers/userController');
+const { authMiddleware } = require('../middlewares/auth');
+const { validate } = require('../middlewares/validate');
+
+const router = express.Router();
+
+router.get('/me', authMiddleware, getProfileController);
+
+router.put(
+  '/me',
+  authMiddleware,
+  [
+    body('name').optional().isString(),
+    body('bio').optional().isString(),
+  ],
+  validate,
+  updateProfileController
+);
+
+router.put(
+  '/change-password',
+  authMiddleware,
+  [
+    body('currentPassword').isString().withMessage('Senha atual é obrigatória.'),
+    body('newPassword')
+      .isLength({ min: 8 })
+      .withMessage('A senha deve ter no mínimo 8 caracteres.')
+      .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/)
+      .withMessage('A senha deve conter maiúscula, minúscula, número e caractere especial.'),
+  ],
+  validate,
+  changePasswordController
+);
+
+module.exports = router;

--- a/api/src/services/authService.js
+++ b/api/src/services/authService.js
@@ -16,6 +16,8 @@ const login = async (email, password) => {
         refreshToken,
         user: {
             email: user.email,
+            name: user.name,
+            bio: user.bio,
             licenseExpiresAt: user.licenseExpiresAt,
             role: user.role
         }

--- a/api/src/services/userService.js
+++ b/api/src/services/userService.js
@@ -22,4 +22,28 @@ const createUser = async (
   return newUser;
 };
 
-module.exports = { createUser };
+const getUserById = async (id) => {
+  return User.findById(id).select('-password -refreshTokens');
+};
+
+const updateUserProfile = async (id, data) => {
+  return User.findByIdAndUpdate(id, {
+    name: data.name,
+    bio: data.bio,
+  }, { new: true }).select('-password -refreshTokens');
+};
+
+const changePassword = async (id, currentPassword, newPassword) => {
+  const user = await User.findById(id);
+  if (!user) {
+    throw new Error('Usuário não encontrado.');
+  }
+  const isMatch = await user.comparePassword(currentPassword);
+  if (!isMatch) {
+    throw new Error('Senha atual incorreta.');
+  }
+  user.password = newPassword;
+  await user.save();
+};
+
+module.exports = { createUser, getUserById, updateUserProfile, changePassword };

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -3,14 +3,17 @@
 import AuthForm from "@/components/AuthForm";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
+import { useEffect } from "react";
 
 export default function LoginPage() {
   const router = useRouter();
   const { login, isAuthenticated } = useAuth();
 
-  if (isAuthenticated) {
-    router.push('/');
-  }
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.push('/');
+    }
+  }, [isAuthenticated, router]);
 
   return (
     <div className="flex justify-center items-center h-[calc(100vh-8rem)]">

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/components/ui/use-toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { api } from "@/lib/api";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+const profileSchema = z.object({
+  name: z.string().optional(),
+  bio: z.string().optional(),
+});
+
+const passwordSchema = z.object({
+  currentPassword: z.string(),
+  newPassword: z
+    .string()
+    .min(8, "A senha deve ter no mínimo 8 caracteres")
+    .regex(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/,
+      "A senha deve conter maiúscula, minúscula, número e caractere especial"
+    ),
+});
+
+export default function ProfilePage() {
+  const { logout, isAuthenticated } = useAuth();
+  const { toast } = useToast();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push('/login');
+    }
+  }, [isAuthenticated, router]);
+
+  const { data } = useQuery({
+    queryKey: ["profile"],
+    queryFn: () => api.get("/users/me").then((res) => res.data),
+  });
+
+  const profileForm = useForm<z.infer<typeof profileSchema>>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: { name: "", bio: "" },
+  });
+
+  const passwordForm = useForm<z.infer<typeof passwordSchema>>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: { currentPassword: "", newPassword: "" },
+  });
+
+  const updateProfile = useMutation({
+    mutationFn: (values: z.infer<typeof profileSchema>) => api.put("/users/me", values),
+    onSuccess: () => {
+      toast({ title: "Perfil atualizado" });
+    },
+    onError: () => {
+      toast({ title: "Erro ao atualizar perfil", variant: "destructive" });
+    },
+  });
+
+  const updatePassword = useMutation({
+    mutationFn: (values: z.infer<typeof passwordSchema>) => api.put("/users/change-password", values),
+    onSuccess: () => {
+      toast({ title: "Senha atualizada" });
+      passwordForm.reset();
+    },
+    onError: () => {
+      toast({ title: "Erro ao atualizar senha", variant: "destructive" });
+    },
+  });
+
+  const handleLogout = async () => {
+    await logout();
+    router.push("/login");
+  };
+
+  if (data && !profileForm.getValues("name") && !profileForm.getValues("bio")) {
+    profileForm.reset({ name: data.name || "", bio: data.bio || "" });
+  }
+
+  return (
+    <div className="max-w-xl mx-auto space-y-8">
+      <h1 className="text-2xl font-bold text-foreground">Perfil</h1>
+
+      <Form {...profileForm}>
+        <form
+          onSubmit={profileForm.handleSubmit((values) => updateProfile.mutate(values))}
+          className="space-y-4 bg-background border border-secondary rounded p-4"
+        >
+          <div>
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" value={data?.email} disabled />
+          </div>
+          <FormField
+            control={profileForm.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Nome</FormLabel>
+                <FormControl>
+                  <Input placeholder="Opcional" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={profileForm.control}
+            name="bio"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Bio</FormLabel>
+                <FormControl>
+                  <Input placeholder="Opcional" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="bg-primary text-primary-foreground">
+            Salvar
+          </Button>
+        </form>
+      </Form>
+
+      <Form {...passwordForm}>
+        <form
+          onSubmit={passwordForm.handleSubmit((values) => updatePassword.mutate(values))}
+          className="space-y-4 bg-background border border-secondary rounded p-4"
+        >
+          <FormField
+            control={passwordForm.control}
+            name="currentPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Senha atual</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={passwordForm.control}
+            name="newPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Nova senha</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="bg-primary text-primary-foreground">
+            Alterar senha
+          </Button>
+        </form>
+      </Form>
+
+      <Button variant="destructive" onClick={handleLogout}>
+        Logout
+      </Button>
+    </div>
+  );
+}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -28,11 +28,19 @@ export default function Header() {
               <Button className="font-semibold">Fazer Upload</Button>
             </Link>
           )}
-          <Link href="/login">
-            <Button variant="ghost" size="icon" aria-label="Entrar">
-              <User className="h-5 w-5" />
-            </Button>
-          </Link>
+          {isAuthenticated ? (
+            <Link href="/profile">
+              <Button variant="ghost" size="icon" aria-label="Perfil">
+                <User className="h-5 w-5" />
+              </Button>
+            </Link>
+          ) : (
+            <Link href="/login">
+              <Button variant="ghost" size="icon" aria-label="Entrar">
+                <User className="h-5 w-5" />
+              </Button>
+            </Link>
+          )}
         </div>
       </div>
     </header>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -4,6 +4,8 @@ import { UseMutateAsyncFunction } from "@tanstack/react-query";
 
 export interface User {
   email: string;
+  name?: string;
+  bio?: string;
   licenseExpiresAt: string;
   role: 'user' | 'admin';
 }


### PR DESCRIPTION
## Summary
- allow optional name and bio on user accounts
- expose profile and password reset endpoints
- add profile page with editing, password change and logout
- fix login redirect and protect profile route

## Testing
- `node ./node_modules/jest/bin/jest.js --detectOpenHandles --forceExit` *(fails: invalid ELF header)*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6898cf341f348322a08e40b608260780