### PR TITLE
fix: avoid redirect during render

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -3,14 +3,17 @@
 import AuthForm from "@/components/AuthForm";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
+import { useEffect } from "react";
 
 export default function LoginPage() {
   const router = useRouter();
   const { login, isAuthenticated } = useAuth();
 
-  if (isAuthenticated) {
-    router.push('/');
-  }
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.push('/');
+    }
+  }, [isAuthenticated, router]);
 
   return (
     <div className="flex justify-center items-center h-[calc(100vh-8rem)]">

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -3,14 +3,17 @@
 import AuthForm from "@/components/AuthForm";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
+import { useEffect } from "react";
 
 export default function RegisterPage() {
   const router = useRouter();
   const { register, isAuthenticated } = useAuth();
 
-  if (isAuthenticated) {
-    router.push('/');
-  }
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.push('/');
+    }
+  }, [isAuthenticated, router]);
 
   return (
     <div className="flex justify-center items-center h-[calc(100vh-8rem)]">


### PR DESCRIPTION
## Summary
- move login redirect logic into useEffect to prevent router updates during render
- move register redirect logic into useEffect to prevent router updates during render

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: How would you like to configure ESLint?)


------
https://chatgpt.com/codex/tasks/task_b_6898d62546f48322bfb506e437e934a9