### PR TITLE
fix: defer redirects until auth state initializes

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -7,13 +7,17 @@ import { useEffect } from "react";
 
 export default function LoginPage() {
   const router = useRouter();
-  const { login, isAuthenticated } = useAuth();
+  const { login, isAuthenticated, isInitialized } = useAuth();
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (isInitialized && isAuthenticated) {
       router.push('/');
     }
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, isInitialized, router]);
+
+  if (!isInitialized) {
+    return null;
+  }
 
   return (
     <div className="flex justify-center items-center h-[calc(100vh-8rem)]">

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -24,25 +24,31 @@ import { z } from "zod";
 import { format } from "date-fns";
 
 export default function ProfilePage() {
-  const { user, logout, isAuthenticated } = useAuth();
+  const { user, logout, isAuthenticated, isInitialized } = useAuth();
   const router = useRouter();
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (isInitialized && !isAuthenticated) {
       router.push("/login");
     }
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, isInitialized, router]);
 
   useEffect(() => {
-    api
-      .get("/users/me")
-      .then((res) => {
-        queryClient.setQueryData(["auth"], { user: res.data });
-      })
-      .catch(() => {});
-  }, [queryClient]);
+    if (isAuthenticated) {
+      api
+        .get("/users/me")
+        .then((res) => {
+          queryClient.setQueryData(["auth"], { user: res.data });
+        })
+        .catch(() => {});
+    }
+  }, [isAuthenticated, queryClient]);
+
+  if (!isInitialized) {
+    return null;
+  }
 
   const profileForm = useForm<z.infer<typeof profileSchema>>({
     resolver: zodResolver(profileSchema),

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -30,12 +30,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const [accessToken, setLocalAccessToken] = useState<string | null>(null);
   const [refreshToken, setLocalRefreshToken] = useState<string | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
     const storedAccessToken = getAccessToken();
     const storedRefreshToken = getRefreshToken();
     if (storedAccessToken) setLocalAccessToken(storedAccessToken);
     if (storedRefreshToken) setLocalRefreshToken(storedRefreshToken);
+    setIsInitialized(true);
   }, []);
 
   const loginMutation = useMutation({
@@ -96,6 +98,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       loginMutation.isPending ||
       registerMutation.isPending ||
       isLicenseLoading,
+    isInitialized,
     login: loginMutation.mutateAsync,
     register: registerMutation.mutateAsync,
     logout: logoutMutation.mutateAsync,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -18,6 +18,7 @@ export interface AuthContextType {
   isAuthenticated: boolean;
   isLicensed: boolean;
   isLoading: boolean;
+  isInitialized: boolean;
   login: UseMutateAsyncFunction<any, Error, LoginData, unknown>;
   register: UseMutateAsyncFunction<any, Error, RegisterData, unknown>;
   logout: UseMutateAsyncFunction<void, Error, void, unknown>;


### PR DESCRIPTION
## Summary
- ensure AuthProvider exposes initialization state for tokens
- update login and profile pages to wait for auth initialization before redirecting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(exits: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6898d8a31dbc83229938f533ccc08eb3