### PR TITLE
fix: run api with npm dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - LICENSE_DAYS=30
       - NODE_ENV=development
       - LOG_LEVEL=info
-    command: sh -c "nodemon src/server.js"
+    command: npm run dev
     depends_on:
       - mongo
     volumes:


### PR DESCRIPTION
## Summary
- run API service via `npm run dev` so nodemon executes within container

## Testing
- `npm test` *(fails: sh: 1: jest: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_6898ed6c8cd48322b802036d26684cc8