### PR TITLE
feat: add optional dark theme

### DIFF
--- a/artwork.html
+++ b/artwork.html
@@ -20,6 +20,7 @@
       <a href="#" class="nav-link">Artistas</a>
     </nav>
     <div class="actions">
+      <button id="theme-toggle" class="btn" aria-label="Alternar tema">🌓</button>
       <button class="btn btn-primary">Fazer Upload</button>
       <a class="avatar" href="/profile.html" aria-label="Perfil">
         <img src="/public/assets/img/avatar-default.svg" alt="Seu perfil">
@@ -56,5 +57,6 @@
     </section>
   </aside>
 </main>
+<script src="/public/js/theme.js"></script>
 </body>
 </html>

--- a/auth.html
+++ b/auth.html
@@ -32,5 +32,6 @@
     </div>
   </section>
 </main>
+<script src="/public/js/theme.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
       <a href="#" class="nav-link">Artistas</a>
     </nav>
     <div class="actions">
+      <button id="theme-toggle" class="btn" aria-label="Alternar tema">🌓</button>
       <button class="btn btn-primary">Fazer Upload</button>
       <a class="avatar" href="/profile.html" aria-label="Perfil">
         <img src="/public/assets/img/avatar-default.svg" alt="Seu perfil">
@@ -49,5 +50,6 @@
 </main>
 
 <script type="module" src="/public/js/app.js"></script>
+<script src="/public/js/theme.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -20,6 +20,7 @@
       <a href="#" class="nav-link">Artistas</a>
     </nav>
     <div class="actions">
+      <button id="theme-toggle" class="btn" aria-label="Alternar tema">🌓</button>
       <button class="btn btn-primary">Fazer Upload</button>
       <a class="avatar" href="/profile.html" aria-label="Perfil">
         <img src="/public/assets/img/avatar-default.svg" alt="Seu perfil">
@@ -52,5 +53,6 @@
 </main>
 
 <script type="module" src="/public/js/profile.js"></script>
+<script src="/public/js/theme.js"></script>
 </body>
 </html>

--- a/public/css/tokens.css
+++ b/public/css/tokens.css
@@ -24,3 +24,8 @@
   --easing: cubic-bezier(.2,.8,.2,1);
   --dur-fast: 120ms; --dur: 240ms; --dur-slow: 420ms;
 }
+
+[data-theme="dark"]{
+  --bg: #1a1a1a;
+  --text: #FAEBB8;
+}

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,0 +1,11 @@
+(() => {
+  const root = document.documentElement;
+  const toggle = document.getElementById('theme-toggle');
+  const preferred = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  root.dataset.theme = preferred;
+  toggle?.addEventListener('click', () => {
+    const next = root.dataset.theme === 'dark' ? 'light' : 'dark';
+    root.dataset.theme = next;
+    localStorage.setItem('theme', next);
+  });
+})();


### PR DESCRIPTION
## Summary
- add CSS variables for dark mode and toggle script
- expose a theme toggle across static pages

## Testing
- `npm test` *(fails: jest Permission denied)*
- `npm run lint` *(requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_6898f7efadac8322a6d26cb678eb7fd3