### PR TITLE
Aplicar tema escuro por padrão

### DIFF
--- a/artwork.html
+++ b/artwork.html
@@ -20,7 +20,6 @@
       <a href="#" class="nav-link">Artistas</a>
     </nav>
     <div class="actions">
-      <button id="theme-toggle" class="btn" aria-label="Alternar tema">🌓</button>
       <button class="btn btn-primary">Fazer Upload</button>
       <a class="avatar" href="/profile.html" aria-label="Perfil">
         <img src="/public/assets/img/avatar-default.svg" alt="Seu perfil">

--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
       <a href="#" class="nav-link">Artistas</a>
     </nav>
     <div class="actions">
-      <button id="theme-toggle" class="btn" aria-label="Alternar tema">🌓</button>
       <button class="btn btn-primary">Fazer Upload</button>
       <a class="avatar" href="/profile.html" aria-label="Perfil">
         <img src="/public/assets/img/avatar-default.svg" alt="Seu perfil">

--- a/profile.html
+++ b/profile.html
@@ -20,7 +20,6 @@
       <a href="#" class="nav-link">Artistas</a>
     </nav>
     <div class="actions">
-      <button id="theme-toggle" class="btn" aria-label="Alternar tema">🌓</button>
       <button class="btn btn-primary">Fazer Upload</button>
       <a class="avatar" href="/profile.html" aria-label="Perfil">
         <img src="/public/assets/img/avatar-default.svg" alt="Seu perfil">

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,11 +1,5 @@
 (() => {
   const root = document.documentElement;
-  const toggle = document.getElementById('theme-toggle');
-  const preferred = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-  root.dataset.theme = preferred;
-  toggle?.addEventListener('click', () => {
-    const next = root.dataset.theme === 'dark' ? 'light' : 'dark';
-    root.dataset.theme = next;
-    localStorage.setItem('theme', next);
-  });
+  root.dataset.theme = 'dark';
+  localStorage.setItem('theme', 'dark');
 })();


### PR DESCRIPTION
## Summary
- aplicar tema escuro permanente no script de tema
- remover botões de alternância de tema das páginas

## Testing
- `npm test` *(falha: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6898fb8d56cc8322b6fc38d230c100f1