### PR TITLE
feat: switch web theme to dark

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3,8 +3,8 @@
 @tailwind utilities;
 
 :root {
-  --background: #FAEBB8;
-  --foreground: #383838;
+  --background: #383838;
+  --foreground: #FAEBB8;
   --color-primary: #934232;
   --color-primary-foreground: #FAEBB8;
   --color-secondary: #416693;


### PR DESCRIPTION
## Summary
- swap background and foreground colors to enable dark theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompting for ESLint config)*
- `npm run build` *(fails: Argument of type '{ title: string; }' is not assignable to parameter of type 'Omit<ToasterToast, "id">')*

------
https://chatgpt.com/codex/tasks/task_b_6898febb6fdc8322bce14a77a641ff92