### PR TITLE
chore: remove artist filters and set Luna as main artist

### DIFF
--- a/artwork.html
+++ b/artwork.html
@@ -17,7 +17,6 @@
     <a class="logo" href="/">Galeria Pexe</a>
     <nav class="nav" aria-label="Principal">
       <a href="/index.html" class="nav-link">Explorar</a>
-      <a href="#" class="nav-link">Artistas</a>
     </nav>
     <div class="actions">
       <button class="btn btn-primary">Fazer Upload</button>
@@ -35,8 +34,8 @@
   <aside class="meta">
     <h1 class="title">Retrato em Terracota</h1>
     <a class="artist" href="#">
-      <img class="avatar" src="/public/assets/img/artist.svg" alt="Avatar">
-      <span>Ana Souza</span>
+      <img class="avatar" src="/public/assets/img/artist.svg" alt="Avatar de Luna">
+      <span>Luna</span>
     </a>
     <p class="desc">Descrição da obra...</p>
     <div class="tags">

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <a class="logo" href="/">Galeria Pexe</a>
     <nav class="nav" aria-label="Principal">
       <a href="/index.html" class="nav-link">Explorar</a>
-      <a href="#" class="nav-link">Artistas</a>
     </nav>
     <div class="actions">
       <button class="btn btn-primary">Fazer Upload</button>
@@ -36,7 +35,7 @@
     <button class="chip">Concept</button>
   </div>
   <div class="search">
-    <input type="search" placeholder="Buscar por título, artista ou tag" aria-label="Buscar">
+    <input type="search" placeholder="Buscar por título ou tag" aria-label="Buscar">
   </div>
 </section>
 

--- a/profile.html
+++ b/profile.html
@@ -17,7 +17,6 @@
     <a class="logo" href="/">Galeria Pexe</a>
     <nav class="nav" aria-label="Principal">
       <a href="/index.html" class="nav-link">Explorar</a>
-      <a href="#" class="nav-link">Artistas</a>
     </nav>
     <div class="actions">
       <button class="btn btn-primary">Fazer Upload</button>
@@ -30,13 +29,13 @@
 
 <main class="container profile">
   <section class="profile-header">
-    <img class="avatar" src="/public/assets/img/artist.svg" alt="Avatar de Ana Souza">
-    <h1 class="title">Ana Souza</h1>
+    <img class="avatar" src="/public/assets/img/artist.svg" alt="Avatar de Luna">
+    <h1 class="title">Luna</h1>
     <p class="bio">Artista de retratos digitais.</p>
     <div class="stats"><span><strong id="count">0</strong> obras</span></div>
     <form class="edit-form" aria-label="Editar perfil">
       <label>Nome
-        <input type="text" value="Ana Souza" required aria-required="true" />
+        <input type="text" value="Luna" required aria-required="true" />
       </label>
       <label>Bio
         <textarea rows="3">Artista de retratos digitais.</textarea>

--- a/public/js/data/mock-artworks.json
+++ b/public/js/data/mock-artworks.json
@@ -1,4 +1,4 @@
 [
-  {"id":"1","title":"Retrato em Terracota","artist":"Ana Souza","thumb":"/public/assets/img/a1.svg","image":"/public/assets/img/a1-large.svg","tags":["retrato","digital"]},
+  {"id":"1","title":"Retrato em Terracota","artist":"Luna","thumb":"/public/assets/img/a1.svg","image":"/public/assets/img/a1-large.svg","tags":["retrato","digital"]},
   {"id":"2","title":"Jardim Azul","artist":"L. Moraes","thumb":"/public/assets/img/a2.svg","image":"/public/assets/img/a2-large.svg","tags":["paisagem","aquarela"]}
 ]

--- a/public/js/data/mock-users.json
+++ b/public/js/data/mock-users.json
@@ -1,3 +1,3 @@
 [
-  {"id":"u1","name":"Ana Souza","avatar":"/public/assets/img/artist.svg"}
+  {"id":"u1","name":"Luna","avatar":"/public/assets/img/artist.svg"}
 ]

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -1,7 +1,7 @@
 import { enhanceMasonry } from './modules/masonry.js';
 import { fadeIn, showLoader, hideLoader } from './modules/animations.js';
 
-const USER_NAME = 'Ana Souza';
+const USER_NAME = 'Luna';
 
 async function load(){
   showLoader();

--- a/web/src/app/(public)/page.tsx
+++ b/web/src/app/(public)/page.tsx
@@ -4,8 +4,6 @@ import GalleryGrid from "@/components/GalleryGrid";
 import { api } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
 import { Image } from "@/types";
-import { Input } from "@/components/ui/input";
-import { useState } from "react";
 
 interface GalleryResponse {
   images: Image[];
@@ -15,13 +13,9 @@ interface GalleryResponse {
 }
 
 export default function Home() {
-  const [technique, setTechnique] = useState('');
-  const [artist, setArtist] = useState('');
-  const [date, setDate] = useState('');
-
   const { data, isLoading, isError } = useQuery<GalleryResponse>({
-    queryKey: ['gallery', { technique, artist, date }],
-    queryFn: () => api.get('/gallery', { params: { technique, artist, date } }).then(res => res.data),
+    queryKey: ['gallery'],
+    queryFn: () => api.get('/gallery').then(res => res.data),
     retry: false,
   });
 
@@ -31,11 +25,6 @@ export default function Home() {
   return (
     <div className="flex flex-col gap-8">
       <h1 className="text-3xl font-bold">Galeria de Imagens</h1>
-      <div className="flex flex-wrap gap-4">
-        <Input placeholder="Técnica" value={technique} onChange={(e) => setTechnique(e.target.value)} />
-        <Input placeholder="Artista" value={artist} onChange={(e) => setArtist(e.target.value)} />
-        <Input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
-      </div>
       <GalleryGrid images={data?.images || []} />
     </div>
   );

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -25,7 +25,6 @@ export default function Header() {
         <nav className="ml-8 flex gap-4 text-foreground">
           <Link href="/">Início</Link>
           <Link href="/galeria">Galeria</Link>
-          <Link href="/artistas">Artistas</Link>
           <Link href="/sobre">Sobre</Link>
         </nav>
 


### PR DESCRIPTION
## Summary
- drop technique, artist, and date filters from gallery
- remove Artists menu entry and make Luna the primary artist across pages

## Testing
- `npm run lint` (fails: How would you like to configure ESLint?)
- `npm test` (fails: jest: Permission denied)


------
https://chatgpt.com/codex/tasks/task_b_6899055879408322a4ac00f548ac1084