### PR TITLE
Add admin login and default account

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 
 Este é um monorepo que contém uma API Node.js/Express e um aplicativo web Next.js para uma galeria de imagens. A API gerencia a autenticação de usuários, enquanto o aplicativo web consome essa API para exibir imagens, permitir likes e gerenciar o upload de novas imagens.
 
+## Acesso de Administrador
+
+Por padrão, um usuário administrador é criado automaticamente quando a API inicia.
+Use as credenciais abaixo para acessar a área de upload:
+
+- **Email:** `admin@galeriapexe.com`
+- **Senha:** `Adm1n#2024`
+
 ## Estrutura do Projeto
 
 - `api/`: Backend em Node.js com Express, MongoDB, e JWT para autenticação.

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -2,9 +2,11 @@ const mongoose = require('mongoose');
 const app = require('./app');
 const config = require('./config');
 const { logger } = require('./config/logger');
+const { ensureAdminUser } = require('./utils/ensureAdmin');
 
 mongoose.connect(config.mongoUri)
-    .then(() => {
+    .then(async () => {
+        await ensureAdminUser();
         app.listen(config.port, () => {
             logger.info(`Server running on port ${config.port}`);
         });

--- a/api/src/utils/ensureAdmin.js
+++ b/api/src/utils/ensureAdmin.js
@@ -1,0 +1,15 @@
+const User = require('../models/User');
+
+async function ensureAdminUser() {
+  const email = process.env.ADMIN_EMAIL || 'admin@galeriapexe.com';
+  const password = process.env.ADMIN_PASSWORD || 'Adm1n#2024';
+
+  const existing = await User.findOne({ email });
+  if (!existing) {
+    const admin = new User({ email, password, role: 'admin' });
+    await admin.save();
+    console.log(`Admin user created with email ${email}`);
+  }
+}
+
+module.exports = { ensureAdminUser };

--- a/web/src/app/admin/login/page.tsx
+++ b/web/src/app/admin/login/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import AuthForm from "@/components/AuthForm";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+import { useEffect } from "react";
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const { login, isAuthenticated, user, isInitialized } = useAuth();
+
+  useEffect(() => {
+    if (isInitialized && isAuthenticated) {
+      if (user?.role === 'admin') {
+        router.push('/admin/upload');
+      } else {
+        router.push('/');
+      }
+    }
+  }, [isAuthenticated, isInitialized, user, router]);
+
+  if (!isInitialized) {
+    return null;
+  }
+
+  return (
+    <div className="flex justify-center items-center h-[calc(100vh-8rem)]">
+      <AuthForm type="login" onSubmit={login} />
+    </div>
+  );
+}

--- a/web/src/components/NavBar.tsx
+++ b/web/src/components/NavBar.tsx
@@ -33,9 +33,14 @@ export default function NavBar() {
         {isAuthenticated ? (
           <Button onClick={handleLogout}>Sair</Button>
         ) : (
-          <Link href="/login">
-            <Button>Entrar</Button>
-          </Link>
+          <>
+            <Link href="/login">
+              <Button>Entrar</Button>
+            </Link>
+            <Link href="/admin/login">
+              <Button variant="ghost">Admin</Button>
+            </Link>
+          </>
         )}
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- create default admin user on API startup
- add dedicated admin login page and navbar link
- document default admin credentials

