### PR TITLE
feat: support ipv image uploads

### DIFF
--- a/web/src/app/admin/upload/page.tsx
+++ b/web/src/app/admin/upload/page.tsx
@@ -108,7 +108,11 @@ export default function UploadPage() {
               <FormItem>
                 <FormLabel>Imagem do Paint</FormLabel>
                 <FormControl>
-                  <Input type="file" accept="image/*" onChange={(e) => field.onChange(e.target.files)} />
+                  <Input
+                    type="file"
+                    accept="image/*,.ipv"
+                    onChange={(e) => field.onChange(e.target.files)}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/web/src/lib/validators.ts
+++ b/web/src/lib/validators.ts
@@ -38,7 +38,17 @@ export const imageSchema = z.object({
     .any()
     .refine((file) => file && file.length > 0, {
       message: "Imagem é obrigatória.",
-    }),
+    })
+    .refine(
+      (file) =>
+        file &&
+        file[0] &&
+        (file[0].type.startsWith("image/") ||
+          file[0].name.toLowerCase().endsWith(".ipv")),
+      {
+        message: "Apenas arquivos de imagem ou IPV são permitidos.",
+      }
+    ),
   video: z.any().optional(),
   tags: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- allow image uploader to select IPV files
- validate that uploads are images or IPV files

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint config)
- `cd api && npm test` (fails: jest: Permission denied)


------
https://chatgpt.com/codex/tasks/task_b_6899142cd6908322b6bc7fa965c91427