### PR TITLE
fix: add accessible dialog title and allow external image hosts

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -8,6 +8,16 @@ const nextConfig = {
         port: '3333',
         pathname: '/uploads/images/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'drive.google.com',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/web/src/components/Lightbox.tsx
+++ b/web/src/components/Lightbox.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Dialog, DialogContent } from "./ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "./ui/dialog";
 import NextImage from "next/image";
 import { Image as ImageType } from "@/types";
 import LikeButton from "./LikeButton";
@@ -17,6 +22,10 @@ export default function Lightbox({ isOpen, onClose, image }: LightboxProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="p-0 border-none bg-transparent sm:max-w-3xl">
+        <DialogTitle className="sr-only">{image.title}</DialogTitle>
+        <DialogDescription className="sr-only">
+          {image.description || "Image preview"}
+        </DialogDescription>
         <div className="relative">
           <NextImage
             src={imageUrl}


### PR DESCRIPTION
## Summary
- add hidden `DialogTitle` and `DialogDescription` to Lightbox for accessibility
- allow Google Drive image hosts in Next.js config

