### PR TITLE
fix: prevent duplicate base URL in asset resolver

### DIFF
--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -7,6 +7,10 @@ export function cn(...inputs: ClassValue[]) {
 
 export function resolveAssetUrl(pathname: string) {
   if (!pathname) return "";
+  // Prevent double-prefixing when an absolute URL is provided
+  if (/^https?:\/\//.test(pathname)) {
+    return pathname;
+  }
   const isServer = typeof window === "undefined";
   const internal =
     process.env.ASSET_BASE_URL_INTERNAL ||


### PR DESCRIPTION
## Summary
- avoid prepending asset base when an absolute URL is provided to `resolveAssetUrl`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_689949c8e4e08322b2115f38fe8840cf