### PR TITLE
fix: use internal asset base for SSR images

### DIFF
--- a/web/src/app/(public)/artists/[artistId]/page.tsx
+++ b/web/src/app/(public)/artists/[artistId]/page.tsx
@@ -48,7 +48,7 @@ export default function ArtistPage() {
     return <div className="p-8">Artista não encontrado.</div>;
   }
 
-  const avatarUrl = resolveAssetUrl(artist.avatarUrl);
+  const avatarUrl = resolveAssetUrl(artist.avatarUrl, { internal: true });
 
   return (
     <div className="max-w-4xl mx-auto p-4 space-y-8">

--- a/web/src/components/ImageCard.tsx
+++ b/web/src/components/ImageCard.tsx
@@ -40,7 +40,7 @@ export default function ImageCard({ image }: ImageCardProps) {
   });
 
   const imageUrl =
-    (image.url && resolveAssetUrl(image.url)) ||
+    (image.url && resolveAssetUrl(image.url, { internal: true })) ||
     `${process.env.NEXT_PUBLIC_DRIVE_EMBED_PREFIX}${image.fileId}`;
   const aspectRatio = image.width && image.height ? image.width / image.height : 1;
 

--- a/web/src/components/Lightbox.tsx
+++ b/web/src/components/Lightbox.tsx
@@ -19,9 +19,11 @@ interface LightboxProps {
 }
 
 export default function Lightbox({ isOpen, onClose, image }: LightboxProps) {
-  const imageUrl =
+  const publicUrl =
     (image.url && resolveAssetUrl(image.url)) ||
     `${process.env.NEXT_PUBLIC_DRIVE_EMBED_PREFIX}${image.fileId}`;
+  const internalUrl =
+    (image.url && resolveAssetUrl(image.url, { internal: true })) || publicUrl;
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="p-0 border-none bg-transparent sm:max-w-3xl">
@@ -31,7 +33,7 @@ export default function Lightbox({ isOpen, onClose, image }: LightboxProps) {
         </DialogDescription>
         <div className="relative">
           <NextImage
-            src={imageUrl}
+            src={internalUrl}
             alt={image.title}
             width={image.width || 1200}
             height={image.height || 800}
@@ -39,7 +41,7 @@ export default function Lightbox({ isOpen, onClose, image }: LightboxProps) {
           />
           <div className="absolute top-2 right-2 flex gap-2">
             <LikeButton imageId={image._id} />
-            <ShareButton url={imageUrl} title={image.title} />
+            <ShareButton url={publicUrl} title={image.title} />
           </div>
         </div>
         <div className="p-4 bg-background text-foreground">

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -5,21 +5,30 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function resolveAssetUrl(pathname: string) {
+type ResolveAssetOptions = {
+  /**
+   * When `true`, uses the internal base URL intended for server side
+   * requests (e.g. when running inside Docker containers).
+   * Defaults to `false` which returns the public base URL used by the
+   * browser.
+   */
+  internal?: boolean;
+};
+
+export function resolveAssetUrl(pathname: string, opts: ResolveAssetOptions = {}) {
   if (!pathname) return "";
   // Prevent double-prefixing when an absolute URL is provided
   if (/^https?:\/\//.test(pathname)) {
     return pathname;
   }
-  const isServer = typeof window === "undefined";
-  const internal =
+  const internalBase =
     process.env.ASSET_BASE_URL_INTERNAL ||
     process.env.NEXT_PUBLIC_ASSET_BASE_URL || // fallback
     "http://api:3333";
   const publicBase =
     process.env.NEXT_PUBLIC_ASSET_BASE_URL ||
     "http://localhost:3333";
-  const base = isServer ? internal : publicBase;
+  const base = opts.internal ? internalBase : publicBase;
   return `${base}${pathname.startsWith("/") ? "" : "/"}${pathname}`;
 }
     


### PR DESCRIPTION
## Summary
- allow `resolveAssetUrl` to return internal base URL
- use internal URLs for Next.js image components

