### PR TITLE
Allow localhost images

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -12,6 +12,12 @@ const nextConfig = {
         hostname: 'lh3.googleusercontent.com',
         pathname: '/**',
       },
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '3333',
+        pathname: '/uploads/images/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- enable displaying images hosted on localhost:3333

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_689953eaef6c8322a3dc3761a7487162