### PR TITLE
Allow Cloudinary images

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -13,6 +13,11 @@ const nextConfig = {
         pathname: '/**',
       },
       {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+        pathname: '/**',
+      },
+      {
         protocol: 'http',
         hostname: 'localhost',
         port: '3333',


### PR DESCRIPTION
## Summary
- allow Next.js Image component to load from res.cloudinary.com

