### PR TITLE
feat: mostrar total de usuários

### DIFF
--- a/api/src/controllers/userController.js
+++ b/api/src/controllers/userController.js
@@ -26,4 +26,13 @@ const changePassword = async (req, res, next) => {
   }
 };
 
-module.exports = { getMe, updateMe, changePassword };
+const getUsersCount = async (req, res, next) => {
+  try {
+    const count = await userService.countUsers();
+    res.json({ count });
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getMe, updateMe, changePassword, getUsersCount };

--- a/api/src/routes/userRoutes.js
+++ b/api/src/routes/userRoutes.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const { body } = require('express-validator');
-const { getMe, updateMe, changePassword } = require('../controllers/userController');
+const { getMe, updateMe, changePassword, getUsersCount } = require('../controllers/userController');
 const { authMiddleware } = require('../middlewares/auth');
 const { validate } = require('../middlewares/validate');
 
 const router = express.Router();
 
+router.get('/count', getUsersCount);
 router.get('/me', authMiddleware, getMe);
 
 router.put('/me',

--- a/api/src/services/userService.js
+++ b/api/src/services/userService.js
@@ -35,4 +35,8 @@ const changePassword = async (id, currentPassword, newPassword) => {
   return user;
 };
 
-module.exports = { createUser, getUserById, updateUser, changePassword };
+const countUsers = async () => {
+  return User.countDocuments();
+};
+
+module.exports = { createUser, getUserById, updateUser, changePassword, countUsers };

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -4,10 +4,20 @@ import AuthForm from "@/components/AuthForm";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
 import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
 
 export default function LoginPage() {
   const router = useRouter();
   const { login, isAuthenticated, isInitialized } = useAuth();
+
+  const { data: userCount } = useQuery({
+    queryKey: ["user-count"],
+    queryFn: async () => {
+      const res = await api.get("/users/count");
+      return res.data.count;
+    },
+  });
 
   useEffect(() => {
     if (isInitialized && isAuthenticated) {
@@ -20,8 +30,12 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex justify-center items-center h-[calc(100vh-8rem)]">
+    <div className="flex flex-col justify-center items-center h-[calc(100vh-8rem)]">
       <AuthForm type="login" onSubmit={login} redirectTo="/" />
+      <p className="mt-4 text-center text-sm text-gray-500">
+        <span className="block">Usuários Registrados</span>
+        <span className="text-lg font-semibold">{userCount ?? 0}</span>
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- adicionar endpoint para contar usuários na API
- exibir total de usuários cadastrados na página de login

## Testing
- `npm test` (api) *(falhou: jest: Permission denied)*
- `npm test` (web) *(erro: Missing script: "test")*
- `npm run lint` (web) *(interativo: solicitou configuração)*

------
https://chatgpt.com/codex/tasks/task_b_689963f8eaec8322a60e3eb4bf7fe6aa