### PR TITLE
feat: ajustar layout dos cards para estilo Instagram

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -16,12 +16,13 @@
 .chip:focus-visible{outline:2px dashed var(--bg);outline-offset:2px;}
 .search input{padding:.5rem .75rem;border:1px solid var(--secondary);border-radius:var(--radius-md);}
 
-.art-card{position:relative;border-radius:var(--radius-md);overflow:hidden;box-shadow:var(--shadow-sm);break-inside:avoid;margin:0 0 var(--space-6);}
-.art-card .overlay{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:flex-end;padding:var(--space-4);color:var(--bg);background:rgba(147,66,50,0);opacity:0;transition:opacity var(--dur) var(--easing),background var(--dur) var(--easing);}
-.art-card .title{margin:0;font-family:var(--font-display);}
-.art-card .artist{margin:0;font-size:.875rem;}
-.art-card .like{position:absolute;top:var(--space-2);right:var(--space-2);background:none;border:none;padding:var(--space-2);cursor:pointer;}
-.art-card .like svg{width:24px;height:24px;fill:var(--accent);}
+.art-card{border-radius:var(--radius-md);overflow:hidden;box-shadow:var(--shadow-sm);break-inside:avoid;margin:0 0 var(--space-6);display:flex;flex-direction:column;}
+.art-card img{width:100%;aspect-ratio:1/1;object-fit:cover;display:block;}
+.card-footer{background:var(--bg);padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-2);}
+.card-footer .actions{display:flex;gap:var(--space-4);}
+.card-footer .actions button{background:none;border:none;padding:0;cursor:pointer;}
+.card-footer .actions svg{width:24px;height:24px;fill:var(--text);}
+.card-footer .caption{margin:0;font-size:.875rem;}
 
 .loader{display:flex;justify-content:center;align-items:center;padding:var(--space-8);}
 .loader svg{width:48px;height:48px;}

--- a/public/css/pages/home.css
+++ b/public/css/pages/home.css
@@ -2,8 +2,5 @@
 @media(min-width:480px){.masonry{column-count:2;}}
 @media(min-width:768px){.masonry{column-count:3;}}
 @media(min-width:1200px){.masonry{column-count:4;}}
-.art-card img{width:100%;display:block;}
-.art-card .overlay{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:flex-end;padding:var(--space-4);color:var(--bg);background:rgba(147,66,50,0);opacity:0;transition:opacity var(--dur) var(--easing),background var(--dur) var(--easing);}
-
 .gallery-placeholder{text-align:center;padding:var(--space-8) 0;}
 .gallery-placeholder h2{margin-bottom:var(--space-4);}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,5 +1,5 @@
 import { enhanceMasonry } from './modules/masonry.js';
-import { fadeIn, likeBurst, staggerFadeIn, rotateOnHover, colorTransition, showLoader, hideLoader, hoverPreview } from './modules/animations-extended.js';
+import { fadeIn, likeBurst, staggerFadeIn, rotateOnHover, colorTransition, showLoader, hideLoader } from './modules/animations-extended.js';
 import { toggleLike, isLiked } from './modules/ui.js';
 import { openModal, initModal } from './modules/modal.js';
 import { signElement } from './protect-images.js';
@@ -18,7 +18,7 @@ async function render(){
   const list = document.querySelector('.masonry');
   const placeholder = document.querySelector('.gallery-placeholder');
   list.innerHTML = '';
-  const filtered = state.artworks.filter(a =>
+    const filtered = state.artworks.filter(a =>
     (state.tag==='Tudo' || a.tags.includes(state.tag.toLowerCase())) &&
     (a.title.toLowerCase().includes(state.q) || a.artist.toLowerCase().includes(state.q) || a.tags.join(' ').includes(state.q))
   );
@@ -32,43 +32,47 @@ async function render(){
   placeholder.hidden = true;
   list.style.display = '';
 
-  const frag = document.createDocumentFragment();
-  for (const [i, a] of filtered.entries()) {
-    const card = document.createElement('article');
-    card.className='art-card';
-    card.tabIndex=0;
-    const liked = isLiked(a.id);
-    const img = document.createElement('img');
-    img.setAttribute('data-protected-src', a.thumb);
-    await signElement(img);
-    const overlay = document.createElement('div');
-    overlay.className = 'overlay';
-    overlay.innerHTML = `
-        <h3 class="title">${a.title}</h3>
-        <p class="artist">por ${a.artist}</p>
-        <button class="like ${liked?'is-liked':''}" aria-label="Curtir">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21s-6-4.35-9-7.5S-.5 5.5 2.25 3.75C5-1 12 4.5 12 4.5S19-1 21.75 3.75 21 13.5 12 21z"/></svg>
-        </button>`;
-    card.appendChild(img);
-    card.appendChild(overlay);
-    const likeBtn = overlay.querySelector('.like');
-    likeBtn.addEventListener('click', (e)=>{
-      e.stopPropagation();
-      toggleLike(a.id);
-      likeBtn.classList.toggle('is-liked');
-      likeBurst(likeBtn);
-    });
-    card.addEventListener('click', ()=> openModal(a));
-    card.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); openModal(a); }});
-    frag.appendChild(card);
-    fadeIn(card, i*20);
-  }
-  list.appendChild(frag);
-  enhanceMasonry(list);
-  staggerFadeIn('.masonry', '.art-card');
-  rotateOnHover('.art-card .like');
-  hoverPreview('.art-card');
-  colorTransition('.chip.is-active', {
+    const frag = document.createDocumentFragment();
+    for (const [i, a] of filtered.entries()) {
+      const card = document.createElement('article');
+      card.className='art-card';
+      card.tabIndex=0;
+      const liked = isLiked(a.id);
+      card.innerHTML = `
+        <img data-protected-src="${a.thumb}" alt="${a.title}">
+        <div class="card-footer">
+          <div class="actions">
+            <button class="like ${liked?'is-liked':''}" aria-label="Curtir">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21s-6-4.35-9-7.5S-.5 5.5 2.25 3.75C5-1 12 4.5 12 4.5S19-1 21.75 3.75 21 13.5 12 21z"/></svg>
+            </button>
+            <button class="comment" aria-label="Comentar">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 6c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2h12l4 4V6z"/></svg>
+            </button>
+            <button class="share" aria-label="Compartilhar">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.02-4.11A2.99 2.99 0 0018 7.91a3 3 0 10-2.83-4.11L8.15 7.91A3 3 0 006 7a3 3 0 000 6c1.3 0 2.4-.84 2.82-2l7.12 4.16a3 3 0 102.06-1.08z"/></svg>
+            </button>
+          </div>
+          <p class="caption"><strong>${a.title}</strong> por ${a.artist}</p>
+        </div>`;
+      const img = card.querySelector('img');
+      await signElement(img);
+      const likeBtn = card.querySelector('.like');
+      likeBtn.addEventListener('click', (e)=>{
+        e.stopPropagation();
+        toggleLike(a.id);
+        likeBtn.classList.toggle('is-liked');
+        likeBurst(likeBtn);
+      });
+      card.addEventListener('click', (e)=>{ if(e.target.closest('button')) return; openModal(a); });
+      card.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); openModal(a); }});
+      frag.appendChild(card);
+      fadeIn(card, i*20);
+    }
+    list.appendChild(frag);
+    enhanceMasonry(list);
+    staggerFadeIn('.masonry', '.art-card');
+    rotateOnHover('.art-card .like');
+    colorTransition('.chip.is-active', {
     backgroundColor: ['#934232', '#b95d4a']
   });
 }

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -1,6 +1,7 @@
 import { enhanceMasonry } from './modules/masonry.js';
-import { fadeIn, showLoader, hideLoader, pageIntro, parallaxOnScroll } from './modules/animations-extended.js';
+import { fadeIn, showLoader, hideLoader, pageIntro, parallaxOnScroll, likeBurst, rotateOnHover } from './modules/animations-extended.js';
 import { signElement } from './protect-images.js';
+import { toggleLike, isLiked } from './modules/ui.js';
 
 const USER_NAME = 'Luna';
 
@@ -13,26 +14,46 @@ async function load(){
   await render(mine);
 }
 
-async function render(artworks){
-  const list = document.querySelector('.masonry');
-  const frag = document.createDocumentFragment();
-  for (const [i, a] of artworks.entries()){
-    const card = document.createElement('article');
-    card.className = 'art-card';
-    card.tabIndex = 0;
-    const img = document.createElement('img');
-    img.setAttribute('data-protected-src', a.thumb);
-    await signElement(img);
-    card.appendChild(img);
-    card.addEventListener('click', ()=> location.href = `artwork.html?id=${a.id}`);
-    card.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); card.click(); }});
-    frag.appendChild(card);
-    fadeIn(card, i*20);
+  async function render(artworks){
+    const list = document.querySelector('.masonry');
+    const frag = document.createDocumentFragment();
+    for (const [i, a] of artworks.entries()){
+      const card = document.createElement('article');
+      card.className = 'art-card';
+      card.tabIndex = 0;
+      const liked = isLiked(a.id);
+      card.innerHTML = `
+        <img data-protected-src="${a.thumb}" alt="${a.title}">
+        <div class="card-footer">
+          <div class="actions">
+            <button class="like ${liked?'is-liked':''}" aria-label="Curtir">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21s-6-4.35-9-7.5S-.5 5.5 2.25 3.75C5-1 12 4.5 12 4.5S19-1 21.75 3.75 21 13.5 12 21z"/></svg>
+            </button>
+            <button class="comment" aria-label="Comentar">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 6c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2h12l4 4V6z"/></svg>
+            </button>
+          </div>
+          <p class="caption"><strong>${a.title}</strong></p>
+        </div>`;
+      const img = card.querySelector('img');
+      await signElement(img);
+      const likeBtn = card.querySelector('.like');
+      likeBtn.addEventListener('click', (e)=>{
+        e.stopPropagation();
+        toggleLike(a.id);
+        likeBtn.classList.toggle('is-liked');
+        likeBurst(likeBtn);
+      });
+      card.addEventListener('click', (e)=>{ if(e.target.closest('button')) return; location.href = `artwork.html?id=${a.id}`; });
+      card.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); card.click(); }});
+      frag.appendChild(card);
+      fadeIn(card, i*20);
+    }
+    list.appendChild(frag);
+    document.getElementById('count').textContent = artworks.length;
+    enhanceMasonry(list);
+    rotateOnHover('.art-card .like');
   }
-  list.appendChild(frag);
-  document.getElementById('count').textContent = artworks.length;
-  enhanceMasonry(list);
-}
 
 document.addEventListener('DOMContentLoaded', () => {
   pageIntro('.profile-header', ['.title', '.bio', '.stats', '.edit-form']);


### PR DESCRIPTION
## Resumo
- aplica novo estilo de card com imagem quadrada e rodapé com ações
- atualiza scripts `app` e `profile` para gerar cards nesse formato
- remove estilos antigos de overlay da galeria

## Testes
- `npm test` (api) *(falha: Permission denied)*
- `npm test` (web) *(falha: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_689e9290cffc8322bd5135a5f7b6b142