### PR TITLE
Integra estilo de cards na galeria

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import "@/styles/gallery.css";
 import { Toaster } from "@/components/ui/toaster";
 import Providers from "@/components/Providers";
 import ApiStatusLogger from "@/components/ApiStatusLogger";

--- a/web/src/components/GalleryGrid.tsx
+++ b/web/src/components/GalleryGrid.tsx
@@ -21,10 +21,10 @@ export default function GalleryGrid({ images }: GalleryGridProps) {
   }
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+    <section className="gallery" aria-label="Galeria de imagens">
       {images.map((image) => (
         <ImageCard key={image._id} image={image} />
       ))}
-    </div>
+    </section>
   );
 }

--- a/web/src/components/ImageCard.tsx
+++ b/web/src/components/ImageCard.tsx
@@ -3,10 +3,8 @@
 import NextImage from "next/image";
 import { useState } from "react";
 import { Image as ImageType } from "@/types";
-import { Card } from "./ui/card";
 import Lightbox from "./Lightbox";
 import LikeButton from "./LikeButton";
-import { Button } from "./ui/button";
 import { Trash } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -42,7 +40,6 @@ export default function ImageCard({ image }: ImageCardProps) {
   const imageUrl =
     (image.url && resolveAssetUrl(image.url, { internal: true })) ||
     `${process.env.NEXT_PUBLIC_DRIVE_EMBED_PREFIX}${image.fileId}`;
-  const aspectRatio = image.width && image.height ? image.width / image.height : 1;
 
   const handleDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
@@ -51,40 +48,45 @@ export default function ImageCard({ image }: ImageCardProps) {
 
   return (
     <>
-      <Card
-        className="relative group overflow-hidden cursor-pointer"
+      <article
+        className="card"
         onClick={() => setIsModalOpen(true)}
       >
-        <NextImage
-          src={imageUrl}
-          alt={image.title}
-          width={400}
-          height={Math.round(400 / aspectRatio)}
-          className="object-cover w-full h-full transform transition-transform duration-300 group-hover:scale-105"
-          placeholder="blur"
-          blurDataURL={`data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MDAiIGhlaWdodD0iMjAwIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjREREREREIiAvPjwvc3ZnPg==`}
-        />
-        <div className="absolute inset-0 flex flex-col justify-between p-4 bg-primary/85 opacity-0 group-hover:opacity-100 transition">
-          <div className="flex justify-end gap-2">
-            {user?.role === "admin" && (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleDelete}
-                className="bg-transparent hover:bg-soft/20"
-              >
-                <Trash className="h-6 w-6 text-soft" />
-              </Button>
-            )}
-            <LikeButton imageId={image._id} initialCount={image.likes || 0} />
-          </div>
-          <div className="text-background">
-            <h3 className="font-semibold text-lg">{image.title}</h3>
-            {image.artist && <p className="text-sm">{image.artist}</p>}
+        <div className="card__media">
+          <NextImage
+            src={imageUrl}
+            alt={image.title}
+            fill
+            className="object-cover"
+            sizes="400px"
+          />
+          <div className="card__overlay" aria-hidden="true">
+            <p>{image.title}</p>
           </div>
         </div>
-      </Card>
-      <Lightbox isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} image={image} />
+        <div className="card__actions" onClick={(e) => e.stopPropagation()}>
+          <div className="actions__left">
+            <LikeButton imageId={image._id} initialCount={image.likes || 0} />
+          </div>
+          <div className="actions__right">
+            {user?.role === "admin" && (
+              <button
+                className="iconbtn"
+                aria-label="Excluir"
+                onClick={handleDelete}
+                title="Excluir"
+              >
+                <Trash width={22} height={22} />
+              </button>
+            )}
+          </div>
+        </div>
+      </article>
+      <Lightbox
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        image={image}
+      />
     </>
   );
 }

--- a/web/src/styles/gallery.css
+++ b/web/src/styles/gallery.css
@@ -1,0 +1,103 @@
+/* === GRID DA GALERIA (estilo feed) === */
+.gallery {
+  --gap: 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: var(--gap);
+  padding: 24px;
+}
+
+/* === CARD === */
+.card {
+  border-radius: 16px;
+  overflow: hidden;
+  background: #111;
+  box-shadow: 0 8px 24px rgba(0,0,0,.18);
+  display: flex;
+  flex-direction: column;
+}
+
+/* topo (avatar, nome) — opcional */
+.card__top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  background: #0b0b0b;
+  border-bottom: 1px solid rgba(255,255,255,.06);
+}
+.card__avatar {
+  width: 32px; height: 32px; border-radius: 50%;
+  object-fit: cover;
+}
+.card__user {
+  font: 600 14px system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  color: #fff;
+}
+
+/* mídia quadrada (estilo Instagram) */
+.card__media {
+  position: relative;
+  aspect-ratio: 1 / 1;     /* garante quadrado */
+  width: 100%;
+  background: #000;
+}
+.card__media > img {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transition: transform .35s ease;
+}
+.card:hover .card__media > img { transform: scale(1.03); }
+
+/* fallback bem simples para navegadores sem aspect-ratio */
+@supports not (aspect-ratio: 1 / 1) {
+  .card__media { height: 0; padding-top: 100%; }
+  .card__media > img { position: absolute; top: 0; left: 0; }
+}
+
+/* sobreposição com texto (como no exemplo enviado) */
+.card__overlay {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  padding: 16%;
+  text-align: center;
+  opacity: 0;  /* aparece no hover; para sempre visível, troque para 1 */
+  background: linear-gradient(to top, rgba(0,0,0,.55), rgba(0,0,0,.15), rgba(0,0,0,0));
+  transition: opacity .25s ease;
+}
+.card:hover .card__overlay { opacity: 1; }
+.card__overlay p {
+  color: #fff;
+  font: 600 16px/1.45 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  text-shadow: 0 2px 10px rgba(0,0,0,.6);
+}
+
+/* barra de ações (curtir/comentar/salvar) */
+.card__actions {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 12px;
+  background: #0b0b0b;
+  border-top: 1px solid rgba(255,255,255,.06);
+}
+.actions__left, .actions__right { display: flex; gap: 12px; }
+.iconbtn {
+  display: inline-grid; place-items: center;
+  width: 34px; height: 34px; border-radius: 50%;
+  background: transparent; border: none; color: #fff; cursor: pointer;
+}
+.iconbtn:active { transform: scale(.96); }
+
+/* meta e legenda */
+.card__meta, .card__caption {
+  padding: 8px 12px 0 12px;
+  color: #ddd;
+  font: 400 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+}
+.card__meta { font-weight: 600; }
+.card__caption b { color: #fff; font-weight: 700; }
+
+/* responsividade */
+@media (max-width: 520px) {
+  .gallery { padding: 12px; gap: 12px; }
+}


### PR DESCRIPTION
## Resumo
- adiciona folha de estilos `gallery.css` baseada no layout de cards do Instagram
- aplica classe `gallery` ao grid de imagens
- implementa estrutura de `card` com sobreposição e barra de ações

## Testes
- `npm test` (falhou: Missing script)
- `npm run lint` (interativo: requer configuração inicial do ESLint)


------
https://chatgpt.com/codex/tasks/task_b_689e9a5f1fd88322b4bbb7a55975a4c9