### PR TITLE
feat: ajustes de loading, SEO e cache no frontend

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -18,3 +18,10 @@ npm run dev
 ```
 
 A aplicação ficará disponível em http://localhost:3000.
+
+## Cache e Revalidação
+
+As requisições ao backend utilizam o React Query com `staleTime` de 60 segundos, o que
+garante um cache leve e revalidação automática após esse período ou quando a página é
+focada novamente. As rotas expõem também `sitemap` e `robots` para auxiliar mecanismos
+de busca.

--- a/web/src/app/(public)/artists/[artistId]/page.tsx
+++ b/web/src/app/(public)/artists/[artistId]/page.tsx
@@ -7,6 +7,7 @@ import { api } from "@/lib/api";
 import { Artist, Image as ImageType } from "@/types";
 import GalleryGrid from "@/components/GalleryGrid";
 import FollowButton from "@/components/FollowButton";
+import Loading from "@/components/Loading";
 import { resolveAssetUrl } from "@/lib/utils";
 
 export default function ArtistPage() {
@@ -41,7 +42,7 @@ export default function ArtistPage() {
   });
 
   if (artistLoading) {
-    return <div className="p-8">Carregando...</div>;
+    return <Loading className="p-8" />;
   }
 
   if (!artist) {
@@ -69,7 +70,7 @@ export default function ArtistPage() {
         )}
       </div>
       {imagesLoading ? (
-        <div>Carregando galeria...</div>
+        <Loading message="Carregando galeria..." />
       ) : (
         <GalleryGrid images={images} />
       )}

--- a/web/src/app/(public)/page.tsx
+++ b/web/src/app/(public)/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import GalleryGrid from "@/components/GalleryGrid";
+import Loading from "@/components/Loading";
+import ErrorMessage from "@/components/ErrorMessage";
 import { api } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
 import { Image } from "@/types";
@@ -14,13 +16,15 @@ interface GalleryResponse {
 
 export default function Home() {
   const { data, isLoading, isError } = useQuery<GalleryResponse>({
-    queryKey: ['gallery'],
-    queryFn: () => api.get('/gallery').then(res => res.data),
+    queryKey: ["gallery"],
+    queryFn: () => api.get("/gallery").then((res) => res.data),
     retry: false,
   });
 
-  if (isLoading) return <div>Carregando galeria...</div>;
-  if (isError) return <div>Erro ao carregar galeria.</div>;
+  if (isLoading) return <Loading message="Carregando galeria..." />;
+  if (isError) return (
+    <ErrorMessage message="Erro ao carregar galeria." />
+  );
 
   return (
     <div className="flex flex-col gap-8">

--- a/web/src/app/admin/login/page.tsx
+++ b/web/src/app/admin/login/page.tsx
@@ -1,9 +1,16 @@
 "use client";
 
+import type { Metadata } from "next";
 import AuthForm from "@/components/AuthForm";
+import Loading from "@/components/Loading";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
 import { useEffect } from "react";
+
+export const metadata: Metadata = {
+  title: "Login Administrativo - Galeria de Imagens",
+  description: "Área de acesso restrito para administradores.",
+};
 
 export default function AdminLoginPage() {
   const router = useRouter();
@@ -20,7 +27,7 @@ export default function AdminLoginPage() {
   }, [isAuthenticated, isInitialized, user, router]);
 
   if (!isInitialized) {
-    return null;
+    return <Loading />;
   }
 
   return (

--- a/web/src/app/admin/publications/page.tsx
+++ b/web/src/app/admin/publications/page.tsx
@@ -1,9 +1,17 @@
 "use client";
 
+import type { Metadata } from "next";
 import GalleryGrid from "@/components/GalleryGrid";
+import Loading from "@/components/Loading";
+import ErrorMessage from "@/components/ErrorMessage";
 import { api } from "@/lib/api";
 import { useQuery } from "@tanstack/react-query";
 import { Image } from "@/types";
+
+export const metadata: Metadata = {
+  title: "Publicações - Área Administrativa",
+  description: "Gerencie as publicações da galeria.",
+};
 
 interface GalleryResponse {
   images: Image[];
@@ -19,8 +27,9 @@ export default function PublicationsPage() {
     retry: false,
   });
 
-  if (isLoading) return <div>Carregando galeria...</div>;
-  if (isError) return <div>Erro ao carregar galeria.</div>;
+  if (isLoading) return <Loading message="Carregando galeria..." />;
+  if (isError)
+    return <ErrorMessage message="Erro ao carregar galeria." />;
 
   return (
     <div className="flex flex-col gap-8">

--- a/web/src/app/admin/upload/page.tsx
+++ b/web/src/app/admin/upload/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Metadata } from "next";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -21,6 +22,11 @@ import { useToast } from "@/components/ui/use-toast";
 import { Loader2 } from "lucide-react";
 import { imageSchema } from "@/lib/validators";
 import { useRouter } from "next/navigation";
+
+export const metadata: Metadata = {
+  title: "Upload de Imagem - Área Administrativa",
+  description: "Envie novas imagens para a galeria.",
+};
 
 export default function UploadPage() {
   const router = useRouter();

--- a/web/src/app/contato/page.tsx
+++ b/web/src/app/contato/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contato - Galeria de Imagens",
+  description: "Entre em contato com nossa equipe.",
+};
+
 export default function Contato() {
   return (
     <div className="flex flex-col gap-4">

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import ErrorMessage from "@/components/ErrorMessage";
+
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="p-8 text-center space-y-4">
+      <ErrorMessage message="Ocorreu um erro inesperado." />
+      <button onClick={reset} className="underline">
+        Tentar novamente
+      </button>
+    </div>
+  );
+}

--- a/web/src/app/loading.tsx
+++ b/web/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import Loading from "@/components/Loading";
+
+export default function GlobalLoading() {
+  return <Loading className="p-8" />;
+}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,17 +1,25 @@
 "use client";
 
+import type { Metadata } from "next";
 import AuthForm from "@/components/AuthForm";
+import Loading from "@/components/Loading";
+import ErrorMessage from "@/components/ErrorMessage";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 
+export const metadata: Metadata = {
+  title: "Login - Galeria de Imagens",
+  description: "Acesse sua conta para gerenciar suas imagens.",
+};
+
 export default function LoginPage() {
   const router = useRouter();
   const { login, isAuthenticated, isInitialized } = useAuth();
 
-  const { data: userCount } = useQuery({
+  const { data: userCount, isLoading, isError } = useQuery({
     queryKey: ["user-count"],
     queryFn: async () => {
       const res = await api.get("/users/count");
@@ -25,8 +33,14 @@ export default function LoginPage() {
     }
   }, [isAuthenticated, isInitialized, router]);
 
-  if (!isInitialized) {
-    return null;
+  if (!isInitialized || isLoading) {
+    return <Loading />;
+  }
+
+  if (isError) {
+    return (
+      <ErrorMessage message="Erro ao carregar contagem de usuários." />
+    );
   }
 
   return (

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Metadata } from "next";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
@@ -21,6 +22,11 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { useToast } from "@/components/ui/use-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
+
+export const metadata: Metadata = {
+  title: "Perfil - Galeria de Imagens",
+  description: "Gerencie suas informações pessoais.",
+};
 
 export default function ProfilePage() {
   const { user, logout, isAuthenticated, isInitialized } = useAuth();

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
+import type { Metadata } from "next";
 import AuthForm from "@/components/AuthForm";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
 import { useEffect } from "react";
+
+export const metadata: Metadata = {
+  title: "Registro - Galeria de Imagens",
+  description: "Crie sua conta para compartilhar suas imagens.",
+};
 
 export default function RegisterPage() {
   const router = useRouter();

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,0 +1,9 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  return {
+    rules: [{ userAgent: "*", allow: "/" }],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  return [
+    { url: `${baseUrl}/`, lastModified: new Date() },
+    { url: `${baseUrl}/login`, lastModified: new Date() },
+    { url: `${baseUrl}/register`, lastModified: new Date() },
+    { url: `${baseUrl}/profile`, lastModified: new Date() },
+    { url: `${baseUrl}/contato`, lastModified: new Date() },
+  ];
+}

--- a/web/src/app/sobre/page.tsx
+++ b/web/src/app/sobre/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sobre - Galeria de Imagens",
+  description: "Informações sobre o site.",
+};
+
 export default function Sobre() {
   return (
     <div className="flex flex-col gap-4">

--- a/web/src/components/ErrorMessage.tsx
+++ b/web/src/components/ErrorMessage.tsx
@@ -1,0 +1,7 @@
+export default function ErrorMessage({ message = "Ocorreu um erro.", className = "" }: { message?: string; className?: string }) {
+  return (
+    <div role="alert" className={`text-center text-red-500 ${className}`}>
+      {message}
+    </div>
+  );
+}

--- a/web/src/components/ImageCard.tsx
+++ b/web/src/components/ImageCard.tsx
@@ -50,10 +50,19 @@ export default function ImageCard({ image }: ImageCardProps) {
   return (
     <>
       <article
+        tabIndex={0}
+        role="button"
         className={`card ${showOverlay ? "card--active" : ""}`}
         onClick={() => {
           setIsModalOpen(true);
           setShowOverlay(false);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setIsModalOpen(true);
+            setShowOverlay(false);
+          }
         }}
       >
         <div

--- a/web/src/components/Loading.tsx
+++ b/web/src/components/Loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading({ message = "Carregando...", className = "" }: { message?: string; className?: string }) {
+  return (
+    <div role="status" className={`text-center ${className}`}>
+      {message}
+    </div>
+  );
+}

--- a/web/src/components/Providers.tsx
+++ b/web/src/components/Providers.tsx
@@ -9,7 +9,16 @@ interface ProvidersProps {
 }
 
 export default function Providers({ children }: ProvidersProps) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+          },
+        },
+      })
+  );
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Resumo
- padroniza componentes de carregamento e erro
- adiciona metadados, sitemap e robots
- documenta política de cache e revalidação

## Testes
- `npm test` (falhou: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689fd7efd3688322a26d2846eea63761